### PR TITLE
Fix build and fix imports

### DIFF
--- a/superglue/.babelrc.js
+++ b/superglue/.babelrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  plugins: [
+    ["transform-react-remove-prop-types", {removeImport: true}]
+  ],
   presets: [
     [
       "@babel/preset-env",

--- a/superglue/lib/components/RailsTag.js
+++ b/superglue/lib/components/RailsTag.js
@@ -1,6 +1,8 @@
 import React from 'react'
-import parse, { domToReact } from 'html-react-parser'
-import attributesToProps from 'html-react-parser/lib/attributes-to-props'
+import parse, {
+  domToReact,
+  attributesToProps,
+} from 'html-react-parser'
 import PropTypes from 'prop-types'
 
 export default class RailsTag extends React.Component {

--- a/superglue/package.json
+++ b/superglue/package.json
@@ -50,15 +50,16 @@
     "redux-thunk": "^2.3.0"
   },
   "peerDependencies": {
+    "history": "^5.3.0",
     "html-react-parser": ">=1.2.6",
     "react": ">=16",
-    "redux": ">=4.1",
-    "history": "^5.3.0",
     "react-redux": ">=7.2",
+    "redux": ">=4.1",
     "redux-thunk": ">=2.3"
   },
   "dependencies": {
     "abortcontroller-polyfill": "^1.7.3",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "url-parse": "^1.5.1"
   }
 }


### PR DESCRIPTION
Remove proptypes from the build, this was causing issues when importing the package.

Additionally, we import `attributesToProps` from html-react-parser instead of the package file, this was causing issues in esbuild.