### PR TITLE
Update generated layout to use explicit cased keys

### DIFF
--- a/docs/page-response.md
+++ b/docs/page-response.md
@@ -34,7 +34,7 @@ you can customize this to fit your needs.
 
 ```ruby
 # application.json.props
-json.component_identifier virtual_path_of_template
+json.componentIdentifier virtual_path_of_template
 ```
 
 You can control which `componentIdentifier` will render which component in the

--- a/superglue/lib/components/Nav.js
+++ b/superglue/lib/components/Nav.js
@@ -179,7 +179,7 @@ class Nav extends React.Component {
     let reminder = ''
     if (!identifier) {
       reminder =
-        'Did you forget to add `json.component_identifier` in your application.json.props layout?'
+        'Did you forget to add `json.componentIdentifier` in your application.json.props layout?'
     }
 
     const error = new Error(

--- a/superglue_rails/lib/generators/rails/templates/edit.json.props
+++ b/superglue_rails/lib/generators/rails/templates/edit.json.props
@@ -8,5 +8,5 @@ end
 json.form(partial: 'form') do
 end
 
-json.<%= singular_table_name%>_path <%= singular_table_name%>_path(@<%=singular_table_name%>)
-json.<%= plural_table_name %>_path <%= plural_table_name %>_path
+json.<%= singular_table_name.camelize(:lower)%>Path <%= singular_table_name%>_path(@<%=singular_table_name%>)
+json.<%= plural_table_name.camelize(:lower) %>Path <%= plural_table_name %>_path

--- a/superglue_rails/lib/generators/rails/templates/index.json.props
+++ b/superglue_rails/lib/generators/rails/templates/index.json.props
@@ -1,15 +1,14 @@
-json.<%= plural_table_name %> do
+json.<%= plural_table_name.camelize(:lower) %> do
   json.array! @<%= plural_table_name %> do |<%= singular_table_name %>|
     <%- attributes_list_with_timestamps.each do |attr| -%>
-    json.<%=attr%> <%= singular_table_name %>.<%=attr%>
+    json.<%=attr%> <%= singular_table_name.camelize(:lower) %>.<%=attr%>
     <%- end -%>
-    json.edit_<%=singular_table_name%>_path edit_<%=singular_table_name%>_path(<%=singular_table_name%>)
-    json.<%=singular_table_name%>_path <%=singular_table_name%>_path(<%=singular_table_name%>)
-    json.delete_form do
+    json.edit<%=singular_table_name.camelize%>Path edit_<%=singular_table_name%>_path(<%=singular_table_name%>)
+    json.<%=singular_table_name.camelize(:lower)%>Path <%=singular_table_name%>_path(<%=singular_table_name%>)
+    json.deleteForm do
       form_props(model: <%=singular_table_name%>, method: :delete)
     end
   end
 end
 
-
-json.new_<%= singular_table_name %>_path new_<%= singular_table_name %>_path
+json.new<%= singular_table_name.camelize %>Path new_<%= singular_table_name %>_path

--- a/superglue_rails/lib/generators/rails/templates/new.json.props
+++ b/superglue_rails/lib/generators/rails/templates/new.json.props
@@ -8,6 +8,6 @@ end
 json.form(partial: 'form') do
 end
 
-json.<%= plural_table_name %>_path <%= plural_table_name %>_path
+json.<%= plural_table_name.camelize(:lower) %>Path <%= plural_table_name %>_path
 
 

--- a/superglue_rails/lib/generators/rails/templates/show.json.props
+++ b/superglue_rails/lib/generators/rails/templates/show.json.props
@@ -1,7 +1,6 @@
 <%- attributes_list_with_timestamps.each do |attr|-%>
-json.<%=attr%> @<%= singular_table_name %>.<%=attr%>
+json.<%=attr.to_s.camelize(:lower)%> @<%= singular_table_name %>.<%=attr%>
 <%- end -%>
 
-
-json.<%= plural_table_name %>_path <%= plural_table_name %>_path
-json.edit_<%= singular_table_name %>_path edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)
+json.<%= plural_table_name.camelize(:lower) %>Path <%= plural_table_name %>_path
+json.edit<%= singular_table_name.camelize %>Path edit_<%= singular_table_name %>_path(@<%= singular_table_name %>)

--- a/superglue_rails/lib/install/templates/web/application.json.props
+++ b/superglue_rails/lib/install/templates/web/application.json.props
@@ -4,13 +4,13 @@ json.data(search: path) do
   yield json
 end
 
-json.component_identifier virtual_path_of_template
+json.componentIdentifier virtual_path_of_template
 json.defers json.deferred!
 json.fragments json.fragments!
 json.assets [ asset_path('application.js') ]
 
 if protect_against_forgery?
-  json.csrf_token form_authenticity_token
+  json.csrfToken form_authenticity_token
 end
 
 if path
@@ -18,9 +18,9 @@ if path
   json.path search_path_to_camelized_param(path)
 end
 
-json.restore_strategy 'fromCacheAndRevisitInBackground'
+json.restoreStrategy 'fromCacheAndRevisitInBackground'
 
-json.rendered_at Time.now.to_i
+json.renderedAt Time.now.to_i
 
 json.slices do
   json.flash flash.to_h

--- a/superglue_rails/superglue.gemspec
+++ b/superglue_rails/superglue.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.files = Dir["MIT-LICENSE", "README.md", "lib/**/*", "app/**/*"]
 
   s.add_dependency "actionpack", ">= 7.0.0"
-  s.add_dependency "props_template", ">= 0.24.0"
-  s.add_dependency "form_props", ">= 0.0.3"
+  s.add_dependency "props_template", ">= 0.30.0"
+  s.add_dependency "form_props", ">= 0.0.5"
 
   s.add_development_dependency "activerecord", ">= 7.0"
   s.add_development_dependency "rake", " ~> 12.0"


### PR DESCRIPTION
PropsTemplate will no longer camelize(:lower). Instead we must explicitly case our keys. This commit updates the generated layout to reflect that.