### PR TITLE
Fixes errors prop in scaffold form generator components

### DIFF
--- a/superglue_rails/lib/generators/rails/templates/edit.json.props
+++ b/superglue_rails/lib/generators/rails/templates/edit.json.props
@@ -1,6 +1,6 @@
-if @post.errors.any?
+if @<%= singular_table_name %>.errors.any?
   json.errors({
-    explanation: "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this post from being saved:",
+    explanation: "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:",
     messages: @<%= singular_table_name %>.errors.full_messages.map{|msg| {body: msg}}
   })
 end

--- a/superglue_rails/lib/generators/rails/templates/new.json.props
+++ b/superglue_rails/lib/generators/rails/templates/new.json.props
@@ -1,6 +1,6 @@
-if @post.errors.any?
+if @<%= singular_table_name %>.errors.any?
   json.errors({
-    explanation: "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this post from being saved:",
+    explanation: "#{pluralize(@<%= singular_table_name %>.errors.count, "error")} prohibited this <%= singular_table_name %> from being saved:",
     messages: @<%= singular_table_name %>.errors.full_messages.map{|msg| {body: msg}}
   })
 end

--- a/superglue_rails/lib/generators/rails/templates/web/edit.js
+++ b/superglue_rails/lib/generators/rails/templates/web/edit.js
@@ -5,14 +5,14 @@ export default function <%= plural_table_name.camelize %>Edit ({
   // visit,
   // remote,
   form,
-  error,
+  errors,
   <%= singular_table_name.camelize(:lower) %>Path,
   <%= plural_table_name.camelize(:lower) %>Path,
 }) {
-  const messagesEl = error && (
+  const messagesEl = errors && (
     <div id="error_explanation">
-      <h2>{ error.explanation }</h2>
-      <ul>{ error.messages.map(({body})=> <li key={body}>{body}</li>) }</ul>
+      <h2>{ errors.explanation }</h2>
+      <ul>{ errors.messages.map(({body})=> <li key={body}>{body}</li>) }</ul>
     </div>
   )
 

--- a/superglue_rails/lib/generators/rails/templates/web/new.js
+++ b/superglue_rails/lib/generators/rails/templates/web/new.js
@@ -5,13 +5,13 @@ export default function <%= plural_table_name.camelize %>New({
   // visit,
   // remote
   form,
-  error,
+  errors,
   <%= plural_table_name.camelize(:lower) %>Path,
 }) {
-  const messagesEl = error && (
+  const messagesEl = errors && (
     <div id="error_explanation">
-      <h2>{ error.explanation }</h2>
-      <ul>{ error.messages.map(({body})=> <li key={body}>{body}</li>) }</ul>
+      <h2>{ errors.explanation }</h2>
+      <ul>{ errors.messages.map(({body})=> <li key={body}>{body}</li>) }</ul>
     </div>
   )
 


### PR DESCRIPTION
The react components generated by the scaffold generator use the `error` prop, but the the props_template loads this as `errors`

- also fixes hard-coded `post` in these forms