### PR TITLE
Use GitHub badge in the README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@
 Use classic Rails to build rich React Redux applications with **NO APIs** and
 **NO client-side routing**.
 
-[![Build Status](https://circleci.com/gh/thoughtbot/superglue.svg?style=shield)](https://circleci.com/gh/thoughtbot/superglue)
+[![Test superglue_js](https://github.com/thoughtbot/superglue/actions/workflows/build_js.yml/badge.svg)](https://github.com/thoughtbot/superglue/actions/workflows/build_js.yml)
+[![Test superglue_rails](https://github.com/thoughtbot/superglue/actions/workflows/build_rails.yml/badge.svg)](https://github.com/thoughtbot/superglue/actions/workflows/build_rails.yml)
 
 Superglue makes React and Redux as productive as Hotwire, Turbo and Stimulus.
 Its inspired by Turbolinks and designed to feel like a natural extension of


### PR DESCRIPTION
We used to use CircleCI for build status badges. We have since moved to using GitHub Actions.

This commit updates the build status badge to use GitHub Actions.

Resolves #50

Ref:
- https://github.com/thoughtbot/superglue/issues/50