### PR TITLE
Add erb-lint exception for ERB templates

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -108,7 +108,7 @@ state to be picked up by React and Redux.
 <% initial_state = controller.render_to_string(formats: [:json], locals: local_assigns, layout: true) %>
 
 <script type="text/javascript">
-  window.SUPERGLUE_INITIAL_PAGE_STATE=<%= initial_state.html_safe %>;
+  window.SUPERGLUE_INITIAL_PAGE_STATE=<%= initial_state.html_safe %>;<%# erblint:disable ErbSafety %>
 </script>
 
 <div id="app"></div>

--- a/superglue_rails/lib/generators/rails/templates/web/edit.html.erb
+++ b/superglue_rails/lib/generators/rails/templates/web/edit.html.erb
@@ -1,7 +1,7 @@
 <%% initial_state = controller.render_to_string(active_template_virtual_path, formats: [:json], locals: local_assigns, layout: true) %>
 
 <script type="text/javascript">
-  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;
+  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;<%%# erblint:disable ErbSafety %>
 </script>
 
 <%%# If you need SSR follow instructions at %>

--- a/superglue_rails/lib/generators/rails/templates/web/index.html.erb
+++ b/superglue_rails/lib/generators/rails/templates/web/index.html.erb
@@ -1,7 +1,7 @@
 <%% initial_state = controller.render_to_string(active_template_virtual_path, formats: [:json], locals: local_assigns, layout: true) %>
 
 <script type="text/javascript">
-  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;
+  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;<%%# erblint:disable ErbSafety %>
 </script>
 
 <%%# If you need SSR follow instructions at %>

--- a/superglue_rails/lib/generators/rails/templates/web/new.html.erb
+++ b/superglue_rails/lib/generators/rails/templates/web/new.html.erb
@@ -1,7 +1,7 @@
 <%% initial_state = controller.render_to_string(active_template_virtual_path, formats: [:json], locals: local_assigns, layout: true) %>
 
 <script type="text/javascript">
-  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;
+  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;<%%# erblint:disable ErbSafety %>
 </script>
 
 <%%# If you need SSR follow instructions at %>

--- a/superglue_rails/lib/generators/rails/templates/web/show.html.erb
+++ b/superglue_rails/lib/generators/rails/templates/web/show.html.erb
@@ -1,7 +1,7 @@
 <%% initial_state = controller.render_to_string(active_template_virtual_path, formats: [:json], locals: local_assigns, layout: true) %>
 
 <script type="text/javascript">
-  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;
+  window.SUPERGLUE_INITIAL_PAGE_STATE=<%%= initial_state.html_safe %>;<%%# erblint:disable ErbSafety %>
 </script>
 
 <%%# If you need SSR follow instructions at %>


### PR DESCRIPTION
Solves #52.

I tested this locally by installing my branch of superglue on a new Rails app. I then used a scaffold to generate files and ensured that the `erb` files showed the new `erblint:disable ErbSafety` comment.