### PR TITLE
Add warning for 406 response code and test cases

### DIFF
--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -37,7 +37,7 @@ export function handleServerErrors(args) {
   const { rsp } = args
   if (!rsp.ok) {
     if (rsp.status === 406) {
-      console.warn(
+      console.error(
           "Superglue encountered a 406 Not Acceptable response. This can happen if you used respond_to and didn't specify format.json in the block. Try adding it to your respond_to. For example:\n\n" +
           "respond_to do |format|\n" +
           "  format.html\n" +
@@ -45,11 +45,10 @@ export function handleServerErrors(args) {
           "  format.csv\n" +
           "end"
       )
-    } else {
-      const error = new Error(rsp.statusText)
-      error.response = rsp
-      throw error
-    }
+    } 
+    const error = new Error(rsp.statusText)
+    error.response = rsp
+    throw error
   }
   return args
 }

--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -38,14 +38,14 @@ export function handleServerErrors(args) {
   if (!rsp.ok) {
     if (rsp.status === 406) {
       console.error(
-          "Superglue encountered a 406 Not Acceptable response. This can happen if you used respond_to and didn't specify format.json in the block. Try adding it to your respond_to. For example:\n\n" +
-          "respond_to do |format|\n" +
-          "  format.html\n" +
-          "  format.json\n" +
-          "  format.csv\n" +
-          "end"
+        "Superglue encountered a 406 Not Acceptable response. This can happen if you used respond_to and didn't specify format.json in the block. Try adding it to your respond_to. For example:\n\n" +
+          'respond_to do |format|\n' +
+          '  format.html\n' +
+          '  format.json\n' +
+          '  format.csv\n' +
+          'end'
       )
-    } 
+    }
     const error = new Error(rsp.statusText)
     error.response = rsp
     throw error

--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -36,9 +36,20 @@ export function validateResponse(args) {
 export function handleServerErrors(args) {
   const { rsp } = args
   if (!rsp.ok) {
-    const error = new Error(rsp.statusText)
-    error.response = rsp
-    throw error
+    if (rsp.status === 406) {
+      console.warn(
+          "Superglue encountered a 406 Not Acceptable response. This can happen if you used respond_to and didn't specify format.json in the block. Try adding it to your respond_to. For example:\n\n" +
+          "respond_to do |format|\n" +
+          "  format.html\n" +
+          "  format.json\n" +
+          "  format.csv\n" +
+          "end"
+      )
+    } else {
+      const error = new Error(rsp.statusText)
+      error.response = rsp
+      throw error
+    }
   }
   return args
 }

--- a/superglue/spec/lib/utils/request.spec.js
+++ b/superglue/spec/lib/utils/request.spec.js
@@ -189,15 +189,15 @@ describe('argsForFetch', () => {
 })
 
 describe('handleServerErrors', () => {
-  let originalConsoleWarn;
+  let originalConsoleError;
 
   beforeAll(() => {
-    originalConsoleWarn = console.warn;
-    console.warn = jest.fn();
+    originalConsoleError = console.error;
+    console.error = jest.fn();
   });
 
   afterAll(() => {
-    console.warn = originalConsoleWarn;
+    console.error = originalConsoleError;
   });
 
   it('warns when 406 response code is received', () => {
@@ -212,14 +212,14 @@ describe('handleServerErrors', () => {
       headers,
     }
 
-    expect(() => handleServerErrors({ rsp })).not.toThrow();
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(() => handleServerErrors({ rsp })).toThrowError('Not Acceptable');
+    expect(console.error).toHaveBeenCalledWith(
         "Superglue encountered a 406 Not Acceptable response. This can happen if you used respond_to and didn't specify format.json in the block. Try adding it to your respond_to. For example:\n\n" +
-        "respond_to do |format|\n" +
-        "  format.html\n" +
-        "  format.json\n" +
-        "  format.csv\n" +
-        "end"
+        'respond_to do |format|\n' +
+        '  format.html\n' +
+        '  format.json\n' +
+        '  format.csv\n' +
+        'end'
     );
   });
 


### PR DESCRIPTION
https://github.com/thoughtbot/superglue/issues/63

This PR adds a warning message when a 406 response code is received. The warning message suggests the developer to add `format.json` to their `respond_to` block to handle remote calls properly.

Changes Made:

- Updated `handleServerErrors` function to log a warning message for 406 response codes.
- Added test cases to ensure the new functionality works as expected.
