### PR TITLE
Update ESLint config to support TypeScript

### DIFF
--- a/superglue/.eslintrc.json
+++ b/superglue/.eslintrc.json
@@ -6,8 +6,10 @@
     },
     "extends": [
         "eslint:recommended",
-        "plugin:react/recommended"
+        "plugin:react/recommended",
+        "plugin:@typescript-eslint/recommended"
     ],
+    "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true
@@ -15,9 +17,26 @@
         "ecmaVersion": 12,
         "sourceType": "module"
     },
-
-    "plugins": [ "prettier", "react" ],
+    "plugins": [
+        "prettier",
+        "react",
+        "@typescript-eslint"
+    ],
     "rules": {
-      "prettier/prettier": ["error"]
-    }
+        "prettier/prettier": ["error"]
+    },
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx"],
+            "parser": "@typescript-eslint/parser",
+            "plugins": ["@typescript-eslint"],
+            "extends": [
+                "eslint:recommended",
+                "plugin:@typescript-eslint/recommended"
+            ],
+            "rules": {
+                "prettier/prettier": ["error"]
+            }
+        }
+    ]
 }

--- a/superglue/package.json
+++ b/superglue/package.json
@@ -4,7 +4,7 @@
   "description": "Use a vanilla Rails with React and Redux",
   "scripts": {
     "test": "jest",
-    "lint": "eslint lib",
+    "lint": "eslint 'lib/**/*.{js,ts,tsx}'",
     "clean": "rm -rf ./dist",
     "copy:package": "cat ./package.json | jq 'del(.scripts)' > dist/package.json",
     "copy:readme": "cp ../README.md dist/",
@@ -30,6 +30,8 @@
     "@babel/preset-env": "^7.14.4",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.24.6",
+    "@typescript-eslint/eslint-plugin": "^4.28.5",
+    "@typescript-eslint/parser": "^4.28.5",
     "core-js": "^2.6.12",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",


### PR DESCRIPTION
(https://github.com/thoughtbot/superglue/issues/66)

### Changes Made

- Updated `.eslintrc.json` to use `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin`.
- Added TypeScript specific rules in the `overrides` section.
- Updated `package.json` to include a lint script that checks both JavaScript and TypeScript files in the `lib` folder.
