### PR TITLE
Add data-sg-replace functionality

### DIFF
--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -152,7 +152,7 @@ export function visit(
     placeholderKey,
     beforeSave = (prevPage, receivedPage) => receivedPage,
     revisit = false,
-    suggestedAction = 'push',
+    action = 'push',
   } = {}
 ) {
   path = withoutBusters(path)
@@ -175,7 +175,7 @@ export function visit(
 
     if (!placeholderKey && hasPropsAt(path)) {
       console.warn(
-        `visit was called with props_at param in the path ${path}, this will be ignore unless you provide a placeholder.`
+        `visit was called with props_at param in the path ${path}, this will be ignored unless you provide a placeholder.`
       )
       path = removePropsAt(path)
     }
@@ -207,9 +207,14 @@ export function visit(
           rsp,
           fetchArgs,
         }
+
         const isGet = fetchArgs[1].method === 'GET'
 
-        meta.suggestedAction = suggestedAction
+        if (action !== undefined) {
+          meta.suggestedAction = action
+        } else {
+          meta.suggestedAction = 'push'
+        }
 
         if (!rsp.redirected && !isGet) {
           meta.suggestedAction = 'replace'

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -152,7 +152,7 @@ export function visit(
     placeholderKey,
     beforeSave = (prevPage, receivedPage) => receivedPage,
     revisit = false,
-    action = 'push',
+    action,
   } = {}
 ) {
   path = withoutBusters(path)
@@ -210,11 +210,7 @@ export function visit(
 
         const isGet = fetchArgs[1].method === 'GET'
 
-        if (action !== undefined) {
-          meta.suggestedAction = action
-        } else {
-          meta.suggestedAction = 'push'
-        }
+        meta.suggestedAction = 'push'
 
         if (!rsp.redirected && !isGet) {
           meta.suggestedAction = 'replace'
@@ -226,6 +222,10 @@ export function visit(
           } else {
             meta.suggestedAction = 'none'
           }
+        }
+
+        if (action) {
+          meta.suggestedAction = action
         }
 
         pageKey = urlToPageKey(rsp.url)

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -152,6 +152,7 @@ export function visit(
     placeholderKey,
     beforeSave = (prevPage, receivedPage) => receivedPage,
     revisit = false,
+    suggestedAction = 'push',
   } = {}
 ) {
   path = withoutBusters(path)
@@ -208,7 +209,8 @@ export function visit(
         }
         const isGet = fetchArgs[1].method === 'GET'
 
-        meta.suggestedAction = 'push'
+        meta.suggestedAction = suggestedAction
+
         if (!rsp.redirected && !isGet) {
           meta.suggestedAction = 'replace'
         }

--- a/superglue/lib/utils/ujs.ts
+++ b/superglue/lib/utils/ujs.ts
@@ -48,11 +48,8 @@ export class HandlerBuilder {
     const hasRemote = !!node.getAttribute(
       this.attributePrefix + '-remote'
     )
-    const hasReplace = !!node.getAttribute(
-      this.attributePrefix + '-replace'
-    )
 
-    return hasVisit || hasRemote || hasReplace
+    return hasVisit || hasRemote
   }
 
   handleSubmit(event) {
@@ -95,7 +92,6 @@ export class HandlerBuilder {
 
   visitOrRemote(linkOrForm, url, opts: any = {}) {
     let target
-    let suggestedAction = 'push'
 
     if (linkOrForm.getAttribute(this.attributePrefix + '-visit')) {
       target = this.visit
@@ -105,21 +101,24 @@ export class HandlerBuilder {
       if (placeholderKey) {
         opts.placeholderKey = urlToPageKey(placeholderKey)
       }
+
+      if (
+        linkOrForm.getAttribute(this.attributePrefix + '-replace')
+      ) {
+        opts.suggestedAction = 'replace'
+      } else {
+        opts.suggestedAction = 'push'
+      }
     }
 
     if (linkOrForm.getAttribute(this.attributePrefix + '-remote')) {
       target = this.remote
     }
 
-    if (linkOrForm.getAttribute(this.attributePrefix + '-replace')) {
-      target = this.visit
-      suggestedAction = 'replace'
-    }
-
     if (!target) {
       return
     } else {
-      return target(url, { ...opts, suggestedAction })
+      return target(url, opts)
     }
   }
 

--- a/superglue/lib/utils/ujs.ts
+++ b/superglue/lib/utils/ujs.ts
@@ -48,8 +48,11 @@ export class HandlerBuilder {
     const hasRemote = !!node.getAttribute(
       this.attributePrefix + '-remote'
     )
+    const hasReplace = !!node.getAttribute(
+      this.attributePrefix + '-replace'
+    )
 
-    return hasVisit || hasRemote
+    return hasVisit || hasRemote || hasReplace
   }
 
   handleSubmit(event) {
@@ -92,6 +95,7 @@ export class HandlerBuilder {
 
   visitOrRemote(linkOrForm, url, opts: any = {}) {
     let target
+    let suggestedAction = 'push'
 
     if (linkOrForm.getAttribute(this.attributePrefix + '-visit')) {
       target = this.visit
@@ -107,10 +111,15 @@ export class HandlerBuilder {
       target = this.remote
     }
 
+    if (linkOrForm.getAttribute(this.attributePrefix + '-replace')) {
+      target = this.visit
+      suggestedAction = 'replace'
+    }
+
     if (!target) {
       return
     } else {
-      return target(url, opts)
+      return target(url, { ...opts, suggestedAction })
     }
   }
 

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -1388,7 +1388,7 @@ Consider using data-sg-visit, the visit function, or redirect_back.`
       const expectedFetchUrl = '/first?props_at=foo'
       store.dispatch(visit(expectedFetchUrl)).then((meta) => {
         expect(console.warn).toHaveBeenCalledWith(
-          'visit was called with props_at param in the path /first?props_at=foo, this will be ignore unless you provide a placeholder.'
+          'visit was called with props_at param in the path /first?props_at=foo, this will be ignored unless you provide a placeholder.'
         )
         done()
       })

--- a/superglue/spec/lib/utils/ujs.spec.js
+++ b/superglue/spec/lib/utils/ujs.spec.js
@@ -166,30 +166,7 @@ describe('ujs', () => {
       const {onClick} = builder.handlers()
       onClick(createFakeRemoteEvent())
 
-      expect(remote).toHaveBeenCalledWith('/foo', {method: 'GET', suggestedAction: 'push'})
-    })
-
-    it('calls visit with replace action if link has data-replace attribute', () => {
-      const ujsAttributePrefix = 'data'
-      const visit = jest.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {}
-        }
-      }
-      const store = {}
-
-      const builder = new HandlerBuilder({
-        ujsAttributePrefix,
-        store,
-        visit,
-        navigatorRef
-     })
-
-      const {onClick} = builder.handlers()
-      onClick(createFakeReplaceEvent())
-
-      expect(visit).toHaveBeenCalledWith('/foo', {method: 'GET', suggestedAction: 'replace'})
+      expect(remote).toHaveBeenCalledWith('/foo', {method: 'GET'})
     })
 
     it('does not call visit on a link that does not have the visit attribute data-visit', () => {
@@ -383,7 +360,6 @@ describe('ujs', () => {
         headers: {
           "content-type": null,
         },
-        suggestedAction: 'push',
         body: {some: 'Body'}
       })
     })


### PR DESCRIPTION
https://github.com/thoughtbot/superglue/issues/62

This PR adds a new data attribute, `data-sg-replace`. This attribute allows for replacing the browser's history state instead of pushing a new state when navigating.

### Changes

- Modified the `visit` function to accept a `suggestedAction` parameter.
- Added a handler for the `data-sg-replace` attribute in the `HandlerBuilder` class.
- Updated the event listeners to check for `data-sg-replace` and pass the appropriate action.
- Added tests for the new `data-sg-replace` functionality.

### Tests

- Added a new test to ensure `visit` is called with the `replace` action when the `data-sg-replace` attribute is present.
- Updated existing tests to ensure they continue to work with the additional context of the `suggestedAction` parameter.
