### PR TITLE
Add type annotations for the reducers and state

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -9,6 +9,7 @@ import {
   UPDATE_FRAGMENTS,
 } from '../actions'
 import { remote } from './requests'
+import { Page, VisitResponse } from '../types'
 export * from './requests'
 
 export function copyPage({ from, to }) {
@@ -21,7 +22,13 @@ export function copyPage({ from, to }) {
   }
 }
 
-export function saveResponse({ pageKey, page }) {
+export function saveResponse({
+  pageKey,
+  page,
+}: {
+  pageKey: string
+  page: VisitResponse
+}): SaveResponseAction {
   pageKey = urlToPageKey(pageKey)
 
   return {
@@ -98,7 +105,10 @@ function updateFragmentsUsing(page) {
   }
 }
 
-export function saveAndProcessPage(pageKey, page) {
+export function saveAndProcessPage(
+  pageKey: string,
+  page: VisitResponse
+) {
   return (dispatch, getState) => {
     pageKey = urlToPageKey(pageKey)
 

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -14,6 +14,7 @@ import {
   SUPERGLUE_ERROR,
 } from '../actions'
 import { copyPage, saveAndProcessPage } from './index'
+import { VisitResponse } from '../types'
 
 function beforeVisit(payload) {
   return {

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -2,3 +2,73 @@ export interface ParsedResponse {
   rsp: Response
   json: any
 }
+
+export type Defer = {
+  url: string
+  type: 'auto' | 'manual'
+  path: string
+}
+
+export type VisitResponse = {
+  data: any
+  componentIdentifier: string
+  assets: string[]
+  csrfToken?: string
+  fragments: Fragment[]
+  defers: Defer[]
+
+  renderedAt: number
+  restoreStrategy:
+    | 'fromCacheOnly'
+    | 'revisitOnly'
+    | 'fromCacheAndRevisitInBackground'
+}
+
+export type Page = VisitResponse & {
+  savedAt: number
+  pageKey: string
+}
+
+export type GraftResponse = VisitResponse & {
+  action: string
+  path: string
+}
+
+export type PageResponse = GraftResponse | VisitResponse
+
+export type Fragment = {
+  type: string
+  path: string
+}
+
+export type AllPages = {
+  [key: string]: Page
+}
+
+export type SuperglueState = {
+  currentPageKey: string
+  pathname: string
+  search: string
+  hash: string
+  csrfToken?: string
+  assets: string[]
+}
+
+export type RootState = {
+  superglue: SuperglueState
+  pages: AllPages
+  [key: string]: any
+}
+
+export type PageOwnProps = {
+  pageKey: string
+  navigateTo: () => void
+  visit: () => void
+  remote: () => void
+}
+
+export type PageComponentProps = PageOwnProps & {
+  fragments: Fragment[]
+  csrfToken?: string
+  [key: string]: any
+}

--- a/superglue/spec/lib/reducers.spec.js
+++ b/superglue/spec/lib/reducers.spec.js
@@ -1,6 +1,6 @@
 import {
   pageReducer,
-  metaReducer,
+  superglueReducer,
   graftNodeOntoPage,
   updateSameFragmentsOnPage,
   appendReceivedFragmentsOntoPage,
@@ -8,7 +8,7 @@ import {
 } from '../../lib/reducers'
 
 describe('reducers', () => {
-  describe('meta reducer', () => {
+  describe('superglue reducer', () => {
     describe('SUPERGLUE_HISTORY_CHANGE', () => {
       it('sets the currentPageKey', () => {
         const prevState = { foo: 'bar' }
@@ -20,7 +20,7 @@ describe('reducers', () => {
             hash: '#title',
           },
         }
-        const nextState = metaReducer(prevState, action)
+        const nextState = superglueReducer(prevState, action)
 
         expect(nextState).toEqual({
           foo: 'bar',
@@ -44,7 +44,7 @@ describe('reducers', () => {
             },
           },
         }
-        const nextState = metaReducer(prevState, action)
+        const nextState = superglueReducer(prevState, action)
 
         expect(nextState).toEqual({
           foo: 'bar',
@@ -63,7 +63,7 @@ describe('reducers', () => {
             csrfToken: 'some_token',
           },
         }
-        const nextState = metaReducer(prevState, action)
+        const nextState = superglueReducer(prevState, action)
 
         expect(nextState).toEqual({
           foo: 'bar',


### PR DESCRIPTION
Incremental typing. I'm sure not everything is correct, but it'll improve as we type other parts of superglue. For now, i'm keeping close parity with what outputted to /dist, which is why you continue to see defaults on reducers.