### PR TITLE
Add remote and visit type annotations

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -63,7 +63,7 @@ export function handleGraft({ pageKey, page }) {
   }
 }
 
-function fetchDeferments(pageKey, defers = []) {
+function fetchDeferments(pageKey: string, defers = []) {
   pageKey = urlToPageKey(pageKey)
   return (dispatch) => {
     const fetches = defers

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -1,3 +1,5 @@
+import { FetchArgs } from './actions'
+
 export * from './actions'
 
 export interface ParsedResponse {
@@ -73,4 +75,34 @@ export type PageComponentProps = PageOwnProps & {
   fragments: Fragment[]
   csrfToken?: string
   [key: string]: any
+}
+
+interface BaseProps {
+  method?: string
+  body?: BodyInit
+  headers?: HeadersInit
+  beforeSave?: (
+    prevPage: VisitResponse,
+    receivedPage: VisitResponse
+  ) => VisitResponse
+}
+
+export interface RemoteProps extends BaseProps {
+  pageKey?: string
+}
+
+export interface VisitProps extends BaseProps {
+  revisit?: boolean
+  placeholderKey?: string
+}
+
+export interface Meta {
+  pageKey: string
+  page: VisitResponse
+  redirected: boolean
+  rsp: Response
+  fetchArgs: FetchArgs
+  componentIdentifier: string
+  needsRefresh: boolean
+  suggestedAction?: 'push' | 'replace' | 'none'
 }

--- a/superglue/lib/utils/react.ts
+++ b/superglue/lib/utils/react.ts
@@ -4,11 +4,12 @@ import {
   saveAndProcessPage,
   copyPage,
 } from '../action_creators'
+import { PageOwnProps, RootState } from '../types'
 import { urlToPageKey } from './url'
 
 export function mapStateToProps(
-  state = { pages: {}, superglue: {} },
-  ownProps
+  state: RootState,
+  ownProps: PageOwnProps
 ) {
   let pageKey = ownProps.pageKey
   const params = ownProps

--- a/superglue/lib/utils/ujs.ts
+++ b/superglue/lib/utils/ujs.ts
@@ -123,15 +123,11 @@ export class HandlerBuilder {
 }
 
 export const ujsHandlers = ({
-  navigatorRef,
-  store,
   ujsAttributePrefix,
   visit,
   remote,
 }) => {
   const builder = new HandlerBuilder({
-    navigatorRef,
-    store,
     visit,
     remote,
     ujsAttributePrefix,


### PR DESCRIPTION
This adds remote and visit type annotations. `npm run type-check` doesn't pass yet, but the output to dist is still acceptable. Its a step in the right direction.