### PR TITLE
Correct page to page filename in modals.md

### DIFF
--- a/docs/recipes/modals.md
+++ b/docs/recipes/modals.md
@@ -42,7 +42,7 @@ end
 content is the same, the `componentIdentifier` is different as that has
 been setup to use the controller and action name.
 
-#### **`page_to_page_mapping.rb`**
+#### **`page_to_page_mapping.js`**
 
 ```js
 import PostIndex from '../views/posts/index'


### PR DESCRIPTION
The file extension for the page to page file was .rb but should have been .js. This corrects it. 