### PR TITLE
Migrate to `createAction`

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -1,7 +1,7 @@
 import { urlToPageKey, getIn } from '../utils'
 import parse from 'url-parse'
 import {
-  SAVE_RESPONSE,
+  saveResponse,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
   updateFragments,
@@ -11,7 +11,6 @@ import { remote } from './requests'
 import {
   CopyAction,
   VisitResponse,
-  SaveResponseAction,
   SaveAndProcessPageThunk,
   DefermentThunk,
   HandleGraftAction,
@@ -21,24 +20,6 @@ import {
   JSONMappable,
 } from '../types'
 export * from './requests'
-
-export function saveResponse({
-  pageKey,
-  page,
-}: {
-  pageKey: string
-  page: VisitResponse
-}): SaveResponseAction {
-  pageKey = urlToPageKey(pageKey)
-
-  return {
-    type: SAVE_RESPONSE,
-    payload: {
-      pageKey,
-      page,
-    },
-  }
-}
 
 function fetchDeferments(
   pageKey: string,

--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -5,14 +5,13 @@ import {
   HANDLE_GRAFT,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
-  UPDATE_FRAGMENTS,
+  updateFragments,
 } from '../actions'
 import { remote } from './requests'
 import {
   CopyAction,
   VisitResponse,
   SaveResponseAction,
-  UpdateFragmentsAction,
   SaveAndProcessPageThunk,
   DefermentThunk,
   HandleGraftAction,
@@ -105,7 +104,7 @@ function fetchDeferments(
   }
 }
 
-function updateFragmentsUsing(page: Page): UpdateFragmentsAction {
+function getChangedFragments(page: Page) {
   const changedFragments: Record<string, JSONMappable> = {}
   page.fragments.forEach((fragment) => {
     const { type, path } = fragment
@@ -114,10 +113,7 @@ function updateFragmentsUsing(page: Page): UpdateFragmentsAction {
     changedFragments[type] = getIn(page, path) as JSONMappable
   })
 
-  return {
-    type: UPDATE_FRAGMENTS,
-    payload: { changedFragments },
-  }
+  return changedFragments
 }
 
 export function saveAndProcessPage(
@@ -140,7 +136,8 @@ export function saveAndProcessPage(
       return dispatch(fetchDeferments(pageKey, defers)).then(() => {
         if (page.fragments.length > 0) {
           const finishedPage = getState().pages[pageKey]
-          dispatch(updateFragmentsUsing(finishedPage))
+          const changedFragments = getChangedFragments(finishedPage)
+          dispatch(updateFragments({ changedFragments }))
           return Promise.resolve()
         }
       })

--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -9,11 +9,9 @@ import {
 } from '../actions'
 import { remote } from './requests'
 import {
-  CopyAction,
   VisitResponse,
   SaveAndProcessPageThunk,
   DefermentThunk,
-  HandleGraftAction,
   GraftResponse,
   Page,
   Defer,

--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -5,7 +5,6 @@ import {
   HANDLE_GRAFT,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
-  COPY_PAGE,
   UPDATE_FRAGMENTS,
 } from '../actions'
 import { remote } from './requests'
@@ -23,22 +22,6 @@ import {
   JSONMappable,
 } from '../types'
 export * from './requests'
-
-export function copyPage({
-  from,
-  to,
-}: {
-  from: string
-  to: string
-}): CopyAction {
-  return {
-    type: COPY_PAGE,
-    payload: {
-      from,
-      to,
-    },
-  }
-}
 
 export function saveResponse({
   pageKey,

--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -2,10 +2,10 @@ import { urlToPageKey, getIn } from '../utils'
 import parse from 'url-parse'
 import {
   SAVE_RESPONSE,
-  HANDLE_GRAFT,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
   updateFragments,
+  handleGraft,
 } from '../actions'
 import { remote } from './requests'
 import {
@@ -33,24 +33,6 @@ export function saveResponse({
 
   return {
     type: SAVE_RESPONSE,
-    payload: {
-      pageKey,
-      page,
-    },
-  }
-}
-
-export function handleGraft({
-  pageKey,
-  page,
-}: {
-  pageKey: string
-  page: GraftResponse
-}): HandleGraftAction {
-  pageKey = urlToPageKey(pageKey)
-
-  return {
-    type: HANDLE_GRAFT,
     payload: {
       pageKey,
       page,

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -11,9 +11,10 @@ import {
   beforeFetch,
   beforeVisit,
   beforeRemote,
+  copyPage,
   SUPERGLUE_ERROR,
 } from '../actions'
-import { copyPage, saveAndProcessPage } from './index'
+import { saveAndProcessPage } from './index'
 import {
   FetchArgs,
   BeforeRemote,

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -9,13 +9,12 @@ import {
 } from '../utils'
 import {
   beforeFetch,
-  BEFORE_VISIT,
+  beforeVisit,
   BEFORE_REMOTE,
   SUPERGLUE_ERROR,
 } from '../actions'
 import { copyPage, saveAndProcessPage } from './index'
 import {
-  BeforeVisit,
   FetchArgs,
   BeforeRemote,
   HandleError,
@@ -28,16 +27,6 @@ import {
   RemoteCreator,
   VisitCreator,
 } from '../types'
-
-function beforeVisit(payload: {
-  fetchArgs: FetchArgs
-  currentPageKey: string
-}): BeforeVisit {
-  return {
-    type: BEFORE_VISIT,
-    payload,
-  }
-}
 
 function beforeRemote(payload: {
   fetchArgs: FetchArgs

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -8,7 +8,7 @@ import {
   removePropsAt,
 } from '../utils'
 import {
-  BEFORE_FETCH,
+  beforeFetch,
   BEFORE_VISIT,
   BEFORE_REMOTE,
   SUPERGLUE_ERROR,
@@ -16,7 +16,6 @@ import {
 import { copyPage, saveAndProcessPage } from './index'
 import {
   BeforeVisit,
-  BeforeFetch,
   FetchArgs,
   BeforeRemote,
   HandleError,
@@ -46,13 +45,6 @@ function beforeRemote(payload: {
 }): BeforeRemote {
   return {
     type: BEFORE_REMOTE,
-    payload,
-  }
-}
-
-function beforeFetch(payload: { fetchArgs: FetchArgs }): BeforeFetch {
-  return {
-    type: BEFORE_FETCH,
     payload,
   }
 }

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -10,7 +10,7 @@ import {
 import {
   beforeFetch,
   beforeVisit,
-  BEFORE_REMOTE,
+  beforeRemote,
   SUPERGLUE_ERROR,
 } from '../actions'
 import { copyPage, saveAndProcessPage } from './index'
@@ -27,16 +27,6 @@ import {
   RemoteCreator,
   VisitCreator,
 } from '../types'
-
-function beforeRemote(payload: {
-  fetchArgs: FetchArgs
-  currentPageKey: string
-}): BeforeRemote {
-  return {
-    type: BEFORE_REMOTE,
-    payload,
-  }
-}
 
 function handleError(err: Error): HandleError {
   return {

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -12,7 +12,7 @@ import {
   beforeVisit,
   beforeRemote,
   copyPage,
-  SUPERGLUE_ERROR,
+  superglueError,
 } from '../actions'
 import { saveAndProcessPage } from './index'
 import {
@@ -29,21 +29,12 @@ import {
   VisitCreator,
 } from '../types'
 
-function handleError(err: Error): HandleError {
-  return {
-    type: SUPERGLUE_ERROR,
-    payload: {
-      message: err.message,
-    },
-  }
-}
-
 function handleFetchErr(
   err: Error,
   fetchArgs: FetchArgs,
   dispatch: Dispatch
 ): never {
-  dispatch(handleError(err))
+  dispatch(superglueError({ message: err.message }))
   throw err
 }
 

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -17,8 +17,6 @@ import {
 import { saveAndProcessPage } from './index'
 import {
   FetchArgs,
-  BeforeRemote,
-  HandleError,
   VisitResponse,
   PageResponse,
   Page,

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -8,7 +8,6 @@ export const SUPERGLUE_ERROR = '@@superglue/ERROR'
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
-export const HISTORY_CHANGE = '@@superglue/HISTORY_CHANGE'
 export const REMOVE_PAGE = '@@superglue/REMOVE_PAGE'
 export const COPY_PAGE = '@@superglue/COPY_PAGE'
 export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
@@ -30,3 +29,9 @@ export const beforeRemote = createAction<{
 export const setCSRFToken = createAction<{
   csrfToken: string | undefined
 }>('@@superglue/SET_CSRF_TOKEN')
+
+export const historyChange = createAction<{
+  pathname: string
+  search: string
+  hash: string
+}>('@@superglue/HISTORY_CHANGE')

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -9,7 +9,6 @@ export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
 export const HISTORY_CHANGE = '@@superglue/HISTORY_CHANGE'
-export const SET_CSRF_TOKEN = '@@superglue/SET_CSRF_TOKEN'
 export const REMOVE_PAGE = '@@superglue/REMOVE_PAGE'
 export const COPY_PAGE = '@@superglue/COPY_PAGE'
 export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
@@ -27,3 +26,7 @@ export const beforeRemote = createAction<{
   currentPageKey: PageKey
   fetchArgs: FetchArgs
 }>('@@superglue/BEFORE_REMOTE')
+
+export const setCSRFToken = createAction<{
+  csrfToken: string | undefined
+}>('@@superglue/SET_CSRF_TOKEN')

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,5 +1,5 @@
 import { createAction } from '@reduxjs/toolkit'
-import { BasicRequestInit, FetchArgs, PageKey } from './types'
+import { BasicRequestInit, FetchArgs, PageKey, JSONValue } from './types'
 
 export const SAVE_RESPONSE = '@@superglue/SAVE_RESPONSE'
 export const HANDLE_GRAFT = '@@superglue/HANDLE_GRAFT'
@@ -8,7 +8,9 @@ export const SUPERGLUE_ERROR = '@@superglue/ERROR'
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
-export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
+export const updateFragments = createAction<{
+  changedFragments: Record<string, JSONValue>
+}>('@@superglue/UPDATE_FRAGMENTS')
 
 export const copyPage = createAction<{ from: PageKey; to: PageKey }>(
   '@@superglue/COPY_PAGE'

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,8 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import { BasicRequestInit, FetchArgs, PageKey } from './types'
 
-export const BEFORE_REMOTE = '@@superglue/BEFORE_REMOTE'
-
 export const SAVE_RESPONSE = '@@superglue/SAVE_RESPONSE'
 export const HANDLE_GRAFT = '@@superglue/HANDLE_GRAFT'
 
@@ -24,3 +22,8 @@ export const beforeVisit = createAction<{
   currentPageKey: PageKey
   fetchArgs: FetchArgs
 }>('@@superglue/BEFORE_VISIT')
+
+export const beforeRemote = createAction<{
+  currentPageKey: PageKey
+  fetchArgs: FetchArgs
+}>('@@superglue/BEFORE_REMOTE')

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -8,9 +8,12 @@ export const SUPERGLUE_ERROR = '@@superglue/ERROR'
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
-export const REMOVE_PAGE = '@@superglue/REMOVE_PAGE'
 export const COPY_PAGE = '@@superglue/COPY_PAGE'
 export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
+
+export const removePage = createAction<{ pageKey: PageKey }>(
+  '@@superglue/REMOVE_PAGE'
+)
 
 export const beforeFetch = createAction<{ fetchArgs: FetchArgs }>(
   '@@superglue/BEFORE_FETCH'

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,8 +1,6 @@
 import { createAction } from '@reduxjs/toolkit'
-import { BasicRequestInit, FetchArgs } from './types'
+import { BasicRequestInit, FetchArgs, PageKey } from './types'
 
-export const BEFORE_FETCH = '@@superglue/BEFORE_FETCH'
-export const BEFORE_VISIT = '@@superglue/BEFORE_VISIT'
 export const BEFORE_REMOTE = '@@superglue/BEFORE_REMOTE'
 
 export const SAVE_RESPONSE = '@@superglue/SAVE_RESPONSE'
@@ -21,3 +19,8 @@ export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
 export const beforeFetch = createAction<{ fetchArgs: FetchArgs }>(
   '@@superglue/BEFORE_FETCH'
 )
+
+export const beforeVisit = createAction<{
+  currentPageKey: PageKey
+  fetchArgs: FetchArgs
+}>('@@superglue/BEFORE_VISIT')

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,21 +1,34 @@
 import { createAction } from '@reduxjs/toolkit'
-import { FetchArgs, PageKey, JSONValue, Page, GraftResponse } from './types'
+import {
+  FetchArgs,
+  PageKey,
+  JSONValue,
+  Page,
+  GraftResponse,
+  VisitResponse,
+} from './types'
 import { urlToPageKey } from './utils'
-
-export const SAVE_RESPONSE = '@@superglue/SAVE_RESPONSE'
 
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
+export const saveResponse = createAction(
+  '@@superglue/SAVE_RESPONSE',
+  ({ pageKey, page }: { pageKey: string; page: VisitResponse }) => {
+    pageKey = urlToPageKey(pageKey)
+
+    return {
+      payload: {
+        pageKey,
+        page,
+      },
+    }
+  }
+)
+
 export const handleGraft = createAction(
   '@@superglue/HANDLE_GRAFT',
-  function prepare({
-    pageKey,
-    page,
-  }: {
-    pageKey: PageKey
-    page: GraftResponse
-  }) {
+  ({ pageKey, page }: { pageKey: string; page: GraftResponse }) => {
     pageKey = urlToPageKey(pageKey)
 
     return {

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -8,8 +8,11 @@ export const SUPERGLUE_ERROR = '@@superglue/ERROR'
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
-export const COPY_PAGE = '@@superglue/COPY_PAGE'
 export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
+
+export const copyPage = createAction<{ from: PageKey; to: PageKey }>(
+  '@@superglue/COPY_PAGE'
+)
 
 export const removePage = createAction<{ pageKey: PageKey }>(
   '@@superglue/REMOVE_PAGE'

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,11 +1,31 @@
 import { createAction } from '@reduxjs/toolkit'
-import { FetchArgs, PageKey, JSONValue } from './types'
+import { FetchArgs, PageKey, JSONValue, Page, GraftResponse } from './types'
+import { urlToPageKey } from './utils'
 
 export const SAVE_RESPONSE = '@@superglue/SAVE_RESPONSE'
-export const HANDLE_GRAFT = '@@superglue/HANDLE_GRAFT'
 
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
+
+export const handleGraft = createAction(
+  '@@superglue/HANDLE_GRAFT',
+  function prepare({
+    pageKey,
+    page,
+  }: {
+    pageKey: PageKey
+    page: GraftResponse
+  }) {
+    pageKey = urlToPageKey(pageKey)
+
+    return {
+      payload: {
+        page,
+        pageKey,
+      },
+    }
+  }
+)
 
 export const superglueError = createAction<{ message: String }>(
   '@@superglue/ERROR'

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,12 +1,15 @@
 import { createAction } from '@reduxjs/toolkit'
-import { BasicRequestInit, FetchArgs, PageKey, JSONValue } from './types'
+import { FetchArgs, PageKey, JSONValue } from './types'
 
 export const SAVE_RESPONSE = '@@superglue/SAVE_RESPONSE'
 export const HANDLE_GRAFT = '@@superglue/HANDLE_GRAFT'
 
-export const SUPERGLUE_ERROR = '@@superglue/ERROR'
 export const GRAFTING_ERROR = '@@superglue/GRAFTING_ERROR'
 export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
+
+export const superglueError = createAction<{ message: String }>(
+  '@@superglue/ERROR'
+)
 
 export const updateFragments = createAction<{
   changedFragments: Record<string, JSONValue>

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -1,3 +1,6 @@
+import { createAction } from '@reduxjs/toolkit'
+import { BasicRequestInit, FetchArgs } from './types'
+
 export const BEFORE_FETCH = '@@superglue/BEFORE_FETCH'
 export const BEFORE_VISIT = '@@superglue/BEFORE_VISIT'
 export const BEFORE_REMOTE = '@@superglue/BEFORE_REMOTE'
@@ -14,3 +17,7 @@ export const SET_CSRF_TOKEN = '@@superglue/SET_CSRF_TOKEN'
 export const REMOVE_PAGE = '@@superglue/REMOVE_PAGE'
 export const COPY_PAGE = '@@superglue/COPY_PAGE'
 export const UPDATE_FRAGMENTS = '@@superglue/UPDATE_FRAGMENTS'
+
+export const beforeFetch = createAction<{ fetchArgs: FetchArgs }>(
+  '@@superglue/BEFORE_FETCH'
+)

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -3,7 +3,6 @@ import {
   FetchArgs,
   PageKey,
   JSONValue,
-  Page,
   GraftResponse,
   VisitResponse,
 } from './types'
@@ -40,7 +39,7 @@ export const handleGraft = createAction(
   }
 )
 
-export const superglueError = createAction<{ message: String }>(
+export const superglueError = createAction<{ message: string }>(
   '@@superglue/ERROR'
 )
 

--- a/superglue/lib/components/Nav.tsx
+++ b/superglue/lib/components/Nav.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { urlToPageKey, pathWithoutBZParams } from '../utils'
-import { REMOVE_PAGE, historyChange } from '../actions'
+import { removePage, historyChange } from '../actions'
 import {
   HistoryState,
   Keypath,
@@ -142,12 +142,7 @@ class Nav extends React.Component<Props, State> {
       this.scrollTo(0, 0)
 
       if (action === 'replace' && prevPageKey && prevPageKey !== nextPageKey) {
-        store.dispatch({
-          type: REMOVE_PAGE,
-          payload: {
-            pageKey: prevPageKey,
-          },
-        })
+        store.dispatch(removePage({pageKey: prevPageKey}))
       }
 
       return true

--- a/superglue/lib/components/Nav.tsx
+++ b/superglue/lib/components/Nav.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { urlToPageKey, pathWithoutBZParams } from '../utils'
-import { REMOVE_PAGE, HISTORY_CHANGE } from '../actions'
+import { REMOVE_PAGE, historyChange } from '../actions'
 import {
   HistoryState,
   Keypath,
@@ -178,10 +178,11 @@ class Nav extends React.Component<Props, State> {
     const state = location.state as HistoryState
 
     if (state && 'superglue' in state) {
-      store.dispatch({
-        type: HISTORY_CHANGE,
-        payload: { pathname, search, hash },
-      })
+      store.dispatch(historyChange({
+        pathname, 
+        search, 
+        hash,
+      }))
 
       if (action !== 'POP') {
         return

--- a/superglue/lib/components/Nav.tsx
+++ b/superglue/lib/components/Nav.tsx
@@ -142,7 +142,7 @@ class Nav extends React.Component<Props, State> {
       this.scrollTo(0, 0)
 
       if (action === 'replace' && prevPageKey && prevPageKey !== nextPageKey) {
-        store.dispatch(removePage({pageKey: prevPageKey}))
+        store.dispatch(removePage({ pageKey: prevPageKey }))
       }
 
       return true
@@ -173,11 +173,13 @@ class Nav extends React.Component<Props, State> {
     const state = location.state as HistoryState
 
     if (state && 'superglue' in state) {
-      store.dispatch(historyChange({
-        pathname, 
-        search, 
-        hash,
-      }))
+      store.dispatch(
+        historyChange({
+          pathname,
+          search,
+          hash,
+        })
+      )
 
       if (action !== 'POP') {
         return

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -23,7 +23,7 @@ export {
   SAVE_RESPONSE,
   UPDATE_FRAGMENTS,
   COPY_PAGE,
-  REMOVE_PAGE,
+  removePage,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
 } from './actions'

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -4,7 +4,7 @@ import { rootReducer } from './reducers'
 import { config } from './config'
 import { urlToPageKey, ujsHandlers, argsForHistory } from './utils'
 import { saveAndProcessPage } from './action_creators'
-import { HISTORY_CHANGE, SET_CSRF_TOKEN } from './actions'
+import { HISTORY_CHANGE, setCSRFToken } from './actions'
 import { ConnectedComponent, Provider, connect } from 'react-redux'
 
 import {
@@ -90,7 +90,7 @@ function start({
         },
       })
       store.dispatch(saveAndProcessPage(initialPageKey, initialPage))
-      store.dispatch({ type: SET_CSRF_TOKEN, payload: { csrfToken } })
+      store.dispatch(setCSRFToken({csrfToken}))
     },
     initialState: pageToInitialState(initialPageKey, initialPage),
     initialPageKey,

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -21,7 +21,7 @@ export {
   beforeVisit,
   beforeRemote,
   SAVE_RESPONSE,
-  UPDATE_FRAGMENTS,
+  updateFragments,
   copyPage,
   removePage,
   GRAFTING_ERROR,

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -80,13 +80,15 @@ function start({
   return {
     reducer: rootReducer,
     prepareStore: function (store: SuperglueStore) {
-      store.dispatch(historyChange({
-        pathname: location.pathname,
-        search: location.query,
-        hash: location.hash,
-      }))
+      store.dispatch(
+        historyChange({
+          pathname: location.pathname,
+          search: location.query,
+          hash: location.hash,
+        })
+      )
       store.dispatch(saveAndProcessPage(initialPageKey, initialPage))
-      store.dispatch(setCSRFToken({csrfToken}))
+      store.dispatch(setCSRFToken({ csrfToken }))
     },
     initialState: pageToInitialState(initialPageKey, initialPage),
     initialPageKey,

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -4,7 +4,7 @@ import { rootReducer } from './reducers'
 import { config } from './config'
 import { urlToPageKey, ujsHandlers, argsForHistory } from './utils'
 import { saveAndProcessPage } from './action_creators'
-import { HISTORY_CHANGE, setCSRFToken } from './actions'
+import { historyChange, setCSRFToken } from './actions'
 import { ConnectedComponent, Provider, connect } from 'react-redux'
 
 import {
@@ -26,7 +26,6 @@ export {
   REMOVE_PAGE,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
-  HISTORY_CHANGE,
 } from './actions'
 
 import { mapStateToProps, mapDispatchToProps } from './utils/react'
@@ -81,14 +80,11 @@ function start({
   return {
     reducer: rootReducer,
     prepareStore: function (store: SuperglueStore) {
-      store.dispatch({
-        type: HISTORY_CHANGE,
-        payload: {
-          pathname: location.pathname,
-          search: location.query,
-          hash: location.hash,
-        },
-      })
+      store.dispatch(historyChange({
+        pathname: location.pathname,
+        search: location.query,
+        hash: location.hash,
+      }))
       store.dispatch(saveAndProcessPage(initialPageKey, initialPage))
       store.dispatch(setCSRFToken({csrfToken}))
     },

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -17,9 +17,9 @@ import {
 import Nav from './components/Nav'
 
 export {
-  BEFORE_FETCH,
-  BEFORE_VISIT,
-  BEFORE_REMOTE,
+  beforeFetch,
+  beforeVisit,
+  beforeRemote,
   SAVE_RESPONSE,
   UPDATE_FRAGMENTS,
   COPY_PAGE,

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -20,7 +20,7 @@ export {
   beforeFetch,
   beforeVisit,
   beforeRemote,
-  SAVE_RESPONSE,
+  saveResponse,
   updateFragments,
   copyPage,
   removePage,

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -22,7 +22,7 @@ export {
   beforeRemote,
   SAVE_RESPONSE,
   UPDATE_FRAGMENTS,
-  COPY_PAGE,
+  copyPage,
   removePage,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,

--- a/superglue/lib/middleware.ts
+++ b/superglue/lib/middleware.ts
@@ -79,12 +79,7 @@ const fragmentMiddleware: Middleware<unknown, RootState, Dispatch> =
       return nextAction
     }
 
-    store.dispatch({
-      type: actions.UPDATE_FRAGMENTS,
-      payload: {
-        changedFragments,
-      },
-    })
+    store.dispatch(actions.updateFragments({ changedFragments }))
 
     return nextAction
   }

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -3,7 +3,7 @@ import {
   SAVE_RESPONSE,
   HANDLE_GRAFT,
   historyChange,
-  COPY_PAGE,
+  copyPage,
   UPDATE_FRAGMENTS,
   setCSRFToken,
   removePage,
@@ -174,6 +174,15 @@ export function pageReducer(
     return nextState
   }
 
+  if (copyPage.match(action)) {
+    const nextState = { ...state }
+    const { from, to } = action.payload
+
+    nextState[urlToPageKey(to)] = JSON.parse(JSON.stringify(nextState[from]))
+
+    return nextState
+  }
+
   switch (action.type) {
     case SAVE_RESPONSE: {
       const { pageKey, page } = action.payload as SaveResponseAction['payload']
@@ -201,14 +210,6 @@ export function pageReducer(
           }
         })
       })
-
-      return nextState
-    }
-    case COPY_PAGE: {
-      const nextState = { ...state }
-      const { from, to } = action.payload as CopyAction['payload']
-
-      nextState[urlToPageKey(to)] = JSON.parse(JSON.stringify(nextState[from]))
 
       return nextState
     }

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -3,7 +3,7 @@ import {
   REMOVE_PAGE,
   SAVE_RESPONSE,
   HANDLE_GRAFT,
-  HISTORY_CHANGE,
+  historyChange,
   COPY_PAGE,
   UPDATE_FRAGMENTS,
   setCSRFToken,
@@ -18,7 +18,6 @@ import {
   GraftResponse,
   SuperglueState,
   SuperglueReducerAction,
-  HistoryChange,
   SaveResponseAction,
   SetCSRFToken,
   HandleGraftAction,
@@ -226,20 +225,20 @@ export function superglueReducer(
     return { ...state, csrfToken: csrfToken }
   }
 
-  switch (action.type) {
-    case HISTORY_CHANGE: {
-      const { pathname, search, hash } =
-        action.payload as HistoryChange['payload']
-      const currentPageKey = urlToPageKey(pathname + search)
+  if (historyChange.match(action)) {
+    const { pathname, search, hash } = action.payload
+    const currentPageKey = urlToPageKey(pathname + search)
 
-      return {
-        ...state,
-        currentPageKey,
-        pathname,
-        search,
-        hash,
-      }
+    return {
+      ...state,
+      currentPageKey,
+      pathname,
+      search,
+      hash,
     }
+  }
+
+  switch (action.type) {
     case SAVE_RESPONSE: {
       const {
         page: { csrfToken, assets },

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -1,6 +1,6 @@
 import { setIn, getIn, urlToPageKey } from '../utils'
 import {
-  SAVE_RESPONSE,
+  saveResponse,
   handleGraft,
   historyChange,
   copyPage,
@@ -18,7 +18,6 @@ import {
   GraftResponse,
   SuperglueState,
   SuperglueReducerAction,
-  SaveResponseAction,
   SetCSRFToken,
   HandleGraftAction,
   CopyAction,
@@ -55,7 +54,7 @@ function constrainPagesSize(state: AllPages) {
   }
 }
 
-function saveResponse(
+function handleSaveResponse(
   state: AllPages,
   pageKey: string,
   page: VisitResponse
@@ -208,15 +207,12 @@ export function pageReducer(
     return handleGraftResponse(state, pageKey, page)
   }
 
-  switch (action.type) {
-    case SAVE_RESPONSE: {
-      const { pageKey, page } = action.payload as SaveResponseAction['payload']
-      return saveResponse(state, pageKey, page)
-    }
-
-    default:
-      return state
+  if (saveResponse.match(action)) {
+    const { pageKey, page } = action.payload
+    return handleSaveResponse(state, pageKey, page)
   }
+
+  return state
 }
 
 export function superglueReducer(
@@ -241,17 +237,15 @@ export function superglueReducer(
     }
   }
 
-  switch (action.type) {
-    case SAVE_RESPONSE: {
-      const {
-        page: { csrfToken, assets },
-      } = action.payload as SaveResponseAction['payload']
+  if (saveResponse.match(action)) {
+    const {
+      page: { csrfToken, assets },
+    } = action.payload
 
-      return { ...state, csrfToken, assets }
-    }
-    default:
-      return state
+    return { ...state, csrfToken, assets }
   }
+
+  return state
 }
 
 export const rootReducer = {

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -4,9 +4,9 @@ import {
   SAVE_RESPONSE,
   HANDLE_GRAFT,
   HISTORY_CHANGE,
-  SET_CSRF_TOKEN,
   COPY_PAGE,
   UPDATE_FRAGMENTS,
+  setCSRFToken,
 } from '../actions'
 import { config } from '../config'
 import {
@@ -221,6 +221,11 @@ export function superglueReducer(
   state: Partial<SuperglueState> = {},
   action: SuperglueReducerAction | UnknownAction
 ): Partial<SuperglueState> {
+  if (setCSRFToken.match(action)) {
+    const { csrfToken } = action.payload as SetCSRFToken['payload']
+    return { ...state, csrfToken: csrfToken }
+  }
+
   switch (action.type) {
     case HISTORY_CHANGE: {
       const { pathname, search, hash } =
@@ -241,10 +246,6 @@ export function superglueReducer(
       } = action.payload as SaveResponseAction['payload']
 
       return { ...state, csrfToken, assets }
-    }
-    case SET_CSRF_TOKEN: {
-      const { csrfToken } = action.payload as SetCSRFToken['payload']
-      return { ...state, csrfToken: csrfToken }
     }
     default:
       return state

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -19,7 +19,6 @@ import {
   SuperglueState,
   JSONMappable,
 } from '../types'
-import { UnknownAction } from 'redux'
 
 function addPlaceholdersToDeferredNodes(existingPage: Page, page: Page): Page {
   const { defers = [] } = existingPage

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -1,4 +1,5 @@
 import { setIn, getIn, urlToPageKey } from '../utils'
+import type { Action } from '@reduxjs/toolkit'
 import {
   saveResponse,
   handleGraft,
@@ -12,16 +13,10 @@ import { config } from '../config'
 import {
   AllPages,
   Page,
-  PageReducerAction,
   VisitResponse,
   Fragment,
   GraftResponse,
   SuperglueState,
-  SuperglueReducerAction,
-  SetCSRFToken,
-  HandleGraftAction,
-  CopyAction,
-  RemovePageAction,
   JSONMappable,
 } from '../types'
 import { UnknownAction } from 'redux'
@@ -134,7 +129,7 @@ export function graftNodeOntoPage(
   return setIn(state, fullPathToNode, node)
 }
 
-export function handleGraftResponse(
+function handleGraftResponse(
   state: AllPages,
   pageKey: string,
   page: GraftResponse
@@ -160,10 +155,7 @@ export function handleGraftResponse(
   ].reduce((memo, fn) => fn(memo), state)
 }
 
-export function pageReducer(
-  state: AllPages = {},
-  action: PageReducerAction | UnknownAction
-): AllPages {
+export function pageReducer(state: AllPages = {}, action: Action): AllPages {
   if (removePage.match(action)) {
     const { pageKey } = action.payload
     const nextState = { ...state }
@@ -217,10 +209,10 @@ export function pageReducer(
 
 export function superglueReducer(
   state: Partial<SuperglueState> = {},
-  action: SuperglueReducerAction | UnknownAction
+  action: Action
 ): Partial<SuperglueState> {
   if (setCSRFToken.match(action)) {
-    const { csrfToken } = action.payload as SetCSRFToken['payload']
+    const { csrfToken } = action.payload
     return { ...state, csrfToken: csrfToken }
   }
 

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -1,7 +1,7 @@
 import { setIn, getIn, urlToPageKey } from '../utils'
 import {
   SAVE_RESPONSE,
-  HANDLE_GRAFT,
+  handleGraft,
   historyChange,
   copyPage,
   updateFragments,
@@ -135,7 +135,7 @@ export function graftNodeOntoPage(
   return setIn(state, fullPathToNode, node)
 }
 
-export function handleGraft(
+export function handleGraftResponse(
   state: AllPages,
   pageKey: string,
   page: GraftResponse
@@ -202,15 +202,16 @@ export function pageReducer(
     return nextState
   }
 
+  if (handleGraft.match(action)) {
+    const { pageKey, page } = action.payload
+
+    return handleGraftResponse(state, pageKey, page)
+  }
+
   switch (action.type) {
     case SAVE_RESPONSE: {
       const { pageKey, page } = action.payload as SaveResponseAction['payload']
       return saveResponse(state, pageKey, page)
-    }
-    case HANDLE_GRAFT: {
-      const { pageKey, page } = action.payload as HandleGraftAction['payload']
-
-      return handleGraft(state, pageKey, page)
     }
 
     default:

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -1,12 +1,12 @@
 import { setIn, getIn, urlToPageKey } from '../utils'
 import {
-  REMOVE_PAGE,
   SAVE_RESPONSE,
   HANDLE_GRAFT,
   historyChange,
   COPY_PAGE,
   UPDATE_FRAGMENTS,
   setCSRFToken,
+  removePage,
 } from '../actions'
 import { config } from '../config'
 import {
@@ -166,6 +166,14 @@ export function pageReducer(
   state: AllPages = {},
   action: PageReducerAction | UnknownAction
 ): AllPages {
+  if (removePage.match(action)) {
+    const { pageKey } = action.payload
+    const nextState = { ...state }
+    delete nextState[pageKey]
+
+    return nextState
+  }
+
   switch (action.type) {
     case SAVE_RESPONSE: {
       const { pageKey, page } = action.payload as SaveResponseAction['payload']
@@ -201,13 +209,6 @@ export function pageReducer(
       const { from, to } = action.payload as CopyAction['payload']
 
       nextState[urlToPageKey(to)] = JSON.parse(JSON.stringify(nextState[from]))
-
-      return nextState
-    }
-    case REMOVE_PAGE: {
-      const { pageKey } = action.payload as RemovePageAction['payload']
-      const nextState = { ...state }
-      delete nextState[pageKey]
 
       return nextState
     }

--- a/superglue/lib/types/actions.ts
+++ b/superglue/lib/types/actions.ts
@@ -1,5 +1,5 @@
 import { VisitResponse, GraftResponse } from '.'
-import { Action } from 'redux'
+import type { Action } from '@reduxjs/toolkit'
 import { BasicRequestInit } from '.'
 
 export interface SaveResponseAction extends Action {
@@ -77,13 +77,6 @@ export interface BeforeRemote extends Action {
   }
 }
 
-export interface BeforeFetch extends Action {
-  type: '@@superglue/BEFORE_FETCH'
-  payload: {
-    fetchArgs: [string, BasicRequestInit]
-  }
-}
-
 export interface HandleError extends Action {
   type: '@@superglue/ERROR'
   payload: {
@@ -111,11 +104,7 @@ export interface GraftingErrorAction extends Action {
   }
 }
 
-export type LifecycleAction =
-  | BeforeFetch
-  | HandleError
-  | BeforeVisit
-  | BeforeRemote
+export type LifecycleAction = HandleError | BeforeVisit | BeforeRemote
 
 export type PageReducerAction =
   | SaveResponseAction
@@ -137,3 +126,4 @@ export type AllAction =
   | GraftingErrorAction
   | SuperglueReducerAction
   | LifecycleAction
+  | Action

--- a/superglue/lib/types/actions.ts
+++ b/superglue/lib/types/actions.ts
@@ -1,64 +1,10 @@
-import { VisitResponse, GraftResponse } from '.'
 import type { Action } from '@reduxjs/toolkit'
 import { BasicRequestInit } from '.'
-
-export interface HandleGraftAction extends Action {
-  type: '@@superglue/HANDLE_GRAFT'
-  payload: {
-    pageKey: string
-    page: GraftResponse
-  }
-}
-
-export interface CopyAction extends Action {
-  type: '@@superglue/COPY_PAGE'
-  payload: {
-    from: string
-    to: string
-  }
-}
-
-export interface RemovePageAction extends Action {
-  type: '@@superglue/REMOVE_PAGE'
-  payload: {
-    pageKey: string
-  }
-}
-
-export interface SetCSRFToken extends Action {
-  type: '@@superglue/SET_CSRF_TOKEN'
-  payload: {
-    csrfToken: string
-  }
-}
 
 /**
  * Tuple of Fetch arguments that Superglue passes to Fetch.
  */
 export type FetchArgs = [string, BasicRequestInit]
-
-export interface BeforeVisit extends Action {
-  type: '@@superglue/BEFORE_VISIT'
-  payload: {
-    fetchArgs: [string, BasicRequestInit]
-    currentPageKey: string
-  }
-}
-
-export interface BeforeRemote extends Action {
-  type: '@@superglue/BEFORE_REMOTE'
-  payload: {
-    fetchArgs: [string, BasicRequestInit]
-    currentPageKey: string
-  }
-}
-
-export interface HandleError extends Action {
-  type: '@@superglue/ERROR'
-  payload: {
-    message: string
-  }
-}
 
 type USER_SPECIFIED_STRING = string
 
@@ -79,22 +25,3 @@ export interface GraftingErrorAction extends Action {
     keyPath: string
   }
 }
-
-export type LifecycleAction = HandleError | BeforeVisit | BeforeRemote
-
-export type PageReducerAction =
-  | HandleGraftAction
-  | GraftingSuccessAction
-  | GraftingErrorAction
-  | CopyAction
-  | RemovePageAction
-
-export type SuperglueReducerAction = SetCSRFToken
-
-export type AllAction =
-  | PageReducerAction
-  | GraftingSuccessAction
-  | GraftingErrorAction
-  | SuperglueReducerAction
-  | LifecycleAction
-  | Action

--- a/superglue/lib/types/actions.ts
+++ b/superglue/lib/types/actions.ts
@@ -33,13 +33,6 @@ export interface RemovePageAction extends Action {
   }
 }
 
-export interface UpdateFragmentsAction extends Action {
-  type: '@@superglue/UPDATE_FRAGMENTS'
-  payload: {
-    changedFragments: Record<string, unknown>
-  }
-}
-
 export interface SetCSRFToken extends Action {
   type: '@@superglue/SET_CSRF_TOKEN'
   payload: {
@@ -104,7 +97,6 @@ export type PageReducerAction =
   | GraftingErrorAction
   | CopyAction
   | RemovePageAction
-  | UpdateFragmentsAction
 
 export type SuperglueReducerAction = SaveResponseAction | SetCSRFToken
 

--- a/superglue/lib/types/actions.ts
+++ b/superglue/lib/types/actions.ts
@@ -2,14 +2,6 @@ import { VisitResponse, GraftResponse } from '.'
 import type { Action } from '@reduxjs/toolkit'
 import { BasicRequestInit } from '.'
 
-export interface SaveResponseAction extends Action {
-  type: '@@superglue/SAVE_RESPONSE'
-  payload: {
-    pageKey: string
-    page: VisitResponse
-  }
-}
-
 export interface HandleGraftAction extends Action {
   type: '@@superglue/HANDLE_GRAFT'
   payload: {
@@ -91,14 +83,13 @@ export interface GraftingErrorAction extends Action {
 export type LifecycleAction = HandleError | BeforeVisit | BeforeRemote
 
 export type PageReducerAction =
-  | SaveResponseAction
   | HandleGraftAction
   | GraftingSuccessAction
   | GraftingErrorAction
   | CopyAction
   | RemovePageAction
 
-export type SuperglueReducerAction = SaveResponseAction | SetCSRFToken
+export type SuperglueReducerAction = SetCSRFToken
 
 export type AllAction =
   | PageReducerAction

--- a/superglue/lib/types/actions.ts
+++ b/superglue/lib/types/actions.ts
@@ -47,15 +47,6 @@ export interface SetCSRFToken extends Action {
   }
 }
 
-export interface HistoryChange extends Action {
-  type: '@@superglue/HISTORY_CHANGE'
-  payload: {
-    pathname: string
-    search: string
-    hash: string
-  }
-}
-
 /**
  * Tuple of Fetch arguments that Superglue passes to Fetch.
  */
@@ -115,10 +106,7 @@ export type PageReducerAction =
   | RemovePageAction
   | UpdateFragmentsAction
 
-export type SuperglueReducerAction =
-  | SaveResponseAction
-  | SetCSRFToken
-  | HistoryChange
+export type SuperglueReducerAction = SaveResponseAction | SetCSRFToken
 
 export type AllAction =
   | PageReducerAction

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -1,11 +1,6 @@
 import { FetchArgs } from './actions'
 import type { Action } from '@reduxjs/toolkit'
-import {
-  EnhancedStore,
-  Tuple,
-  StoreEnhancer,
-  UnknownAction,
-} from '@reduxjs/toolkit'
+import { EnhancedStore, Tuple, StoreEnhancer } from '@reduxjs/toolkit'
 import { ThunkDispatch } from '@reduxjs/toolkit'
 import { ThunkAction } from '@reduxjs/toolkit'
 import Nav from '../components/Nav'

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -1,4 +1,5 @@
-import { AllAction, FetchArgs } from './actions'
+import { FetchArgs } from './actions'
+import type { Action } from '@reduxjs/toolkit'
 import {
   EnhancedStore,
   Tuple,
@@ -303,7 +304,7 @@ export type RemoteCreator = (
   options: RemoteProps
 ) => MetaThunk
 
-export type Dispatch = ThunkDispatch<RootState, undefined, AllAction>
+export type Dispatch = ThunkDispatch<RootState, undefined, Action>
 
 /**
  * A Store created with Redux Toolkit's `configureStore` setup with reducers
@@ -312,7 +313,7 @@ export type Dispatch = ThunkDispatch<RootState, undefined, AllAction>
  */
 export type SuperglueStore = EnhancedStore<
   RootState,
-  AllAction | UnknownAction,
+  Action,
   Tuple<
     [
       StoreEnhancer<{
@@ -358,21 +359,16 @@ export type SaveAndProcessPageThunk = ThunkAction<
   Promise<void>,
   RootState,
   undefined,
-  AllAction
+  Action
 >
 
-export type MetaThunk = ThunkAction<
-  Promise<Meta>,
-  RootState,
-  undefined,
-  AllAction
->
+export type MetaThunk = ThunkAction<Promise<Meta>, RootState, undefined, Action>
 
 export type DefermentThunk = ThunkAction<
   Promise<void[]>,
   RootState,
   undefined,
-  AllAction
+  Action
 >
 
 /** A variation of RequestInit except the headers must be a regular object */

--- a/superglue/lib/utils/react.ts
+++ b/superglue/lib/utils/react.ts
@@ -1,4 +1,5 @@
-import { saveAndProcessPage, copyPage } from '../action_creators'
+import { saveAndProcessPage } from '../action_creators'
+import { copyPage } from '../actions'
 import { Content, PageOwnProps, RootState } from '../types'
 import { urlToPageKey } from './url'
 

--- a/superglue/package.json
+++ b/superglue/package.json
@@ -45,7 +45,6 @@
   },
   "homepage": "https://github.com/thoughtbot/superglue#readme",
   "devDependencies": {
-    "@reduxjs/toolkit": "^2.2.5",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
@@ -67,7 +66,7 @@
     "prettier-eslint": "^16.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-redux": "^7.2.4",
+    "react-redux": "^7.2.9",
     "redux": "^5.0.1",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^3.1.0",
@@ -79,6 +78,7 @@
     "vitest": "^2.0.2"
   },
   "peerDependencies": {
+    "@reduxjs/toolkit": "^2.2.8",
     "react": ">=16",
     "react-redux": ">=7.2",
     "redux": ">=4.1",

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -7,10 +7,9 @@ import {
   remote,
   beforeFetch,
   handleError,
-  saveResponse,
   saveAndProcessPage,
 } from '../../lib/action_creators'
-import { handleGraft } from '../../lib/actions'
+import { handleGraft, saveResponse } from '../../lib/actions'
 import * as helpers from '../../lib/utils/helpers'
 import * as rsp from '../../spec/fixtures'
 

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -5,12 +5,12 @@ import fetchMock from 'fetch-mock'
 import {
   visit,
   remote,
-  handleGraft,
   beforeFetch,
   handleError,
   saveResponse,
   saveAndProcessPage,
 } from '../../lib/action_creators'
+import { handleGraft } from '../../lib/actions'
 import * as helpers from '../../lib/utils/helpers'
 import * as rsp from '../../spec/fixtures'
 

--- a/superglue/spec/lib/middleware.spec.js
+++ b/superglue/spec/lib/middleware.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { fragmentMiddleware } from '../../lib/middleware'
 import { getIn, setIn } from '../../lib/utils/immutability'
-import { historyChange, UPDATE_FRAGMENTS } from '../../lib/actions'
+import { historyChange, updateFragments} from '../../lib/actions'
 
 describe('fragment middleware', () => {
   it('does nothing on superglue actions', () => {
@@ -260,7 +260,7 @@ describe('fragment middleware', () => {
 
     fragmentMiddleware(store)(next)(action)
     expect(store.dispatch).toHaveBeenCalledWith({
-      type: UPDATE_FRAGMENTS,
+      type: updateFragments.type,
       payload: {
         changedFragments: {
           header: {

--- a/superglue/spec/lib/middleware.spec.js
+++ b/superglue/spec/lib/middleware.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { fragmentMiddleware } from '../../lib/middleware'
 import { getIn, setIn } from '../../lib/utils/immutability'
-import { HISTORY_CHANGE, UPDATE_FRAGMENTS } from '../../lib/actions'
+import { historyChange, UPDATE_FRAGMENTS } from '../../lib/actions'
 
 describe('fragment middleware', () => {
   it('does nothing on superglue actions', () => {
@@ -19,10 +19,7 @@ describe('fragment middleware', () => {
       return action
     }
 
-    const action = {
-      type: HISTORY_CHANGE,
-      payload: {},
-    }
+    const action = historyChange({})
 
     expect(fragmentMiddleware(store)(next)(action)).toEqual(action)
     expect(store.dispatch).not.toHaveBeenCalled()

--- a/superglue/spec/lib/middleware.spec.js
+++ b/superglue/spec/lib/middleware.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { fragmentMiddleware } from '../../lib/middleware'
 import { getIn, setIn } from '../../lib/utils/immutability'
-import { historyChange, updateFragments} from '../../lib/actions'
+import { historyChange, updateFragments } from '../../lib/actions'
 
 describe('fragment middleware', () => {
   it('does nothing on superglue actions', () => {

--- a/superglue_rails/lib/install/templates/web/actions.js
+++ b/superglue_rails/lib/install/templates/web/actions.js
@@ -1,6 +1,0 @@
-import { createAction } from '@reduxjs/toolkit'
-import { SAVE_RESPONSE, BEFORE_VISIT, UPDATE_FRAGMENTS } from '@thoughtbot/superglue'
-
-export const saveResponse = createAction(SAVE_RESPONSE)
-export const beforeVisit = createAction(BEFORE_VISIT)
-export const updateFragments = createAction(UPDATE_FRAGMENTS)

--- a/superglue_rails/lib/install/templates/web/flash.js
+++ b/superglue_rails/lib/install/templates/web/flash.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { saveResponse, beforeVisit } from '../actions'
+import { saveResponse, beforeVisit } from '@thoughtbot/superglue'
 
 export const flashSlice = createSlice({
   name: 'flash',

--- a/superglue_rails/lib/install/templates/web/pages.js
+++ b/superglue_rails/lib/install/templates/web/pages.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { saveResponse, beforeVisit } from '../actions'
+import { saveResponse, beforeVisit } from '@thoughtbot/superglue'
 
 export const pagesSlice = createSlice({
   name: 'pages',

--- a/superglue_rails/lib/install/templates/web/store.js
+++ b/superglue_rails/lib/install/templates/web/store.js
@@ -2,9 +2,9 @@ import { configureStore } from '@reduxjs/toolkit'
 import { pagesSlice } from "./slices/pages"
 import { flashSlice } from "./slices/flash"
 import {
-  BEFORE_VISIT,
-  BEFORE_FETCH,
-  BEFORE_REMOTE,
+  beforeVisit,
+  beforeFetch,
+  beforeRemote,
   fragmentMiddleware
 } from '@thoughtbot/superglue'
 
@@ -16,7 +16,7 @@ export const buildStore = (initialState, superglueReducer, supergluePagesReducer
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         serializableCheck: {
-          ignoredActions: [BEFORE_VISIT, BEFORE_FETCH, BEFORE_REMOTE],
+          ignoredActions: [beforeFetch.type, beforeVisit.type, beforeRemote.type],
         },
       }).concat(fragmentMiddleware),
     reducer: {

--- a/superglue_rails/lib/install/web.rb
+++ b/superglue_rails/lib/install/web.rb
@@ -31,9 +31,6 @@ copy_file "#{__dir__}/templates/web/pages.js", "#{app_js_path}/slices/pages.js"
 say "Copying store.js file to #{app_js_path}"
 copy_file "#{__dir__}/templates/web/store.js", "#{app_js_path}/store.js"
 
-say "Copying actions.js file to #{app_js_path}"
-copy_file "#{__dir__}/templates/web/actions.js", "#{app_js_path}/actions.js"
-
 say "Copying application_visit.js file to #{app_js_path}"
 copy_file "#{__dir__}/templates/web/application_visit.js", "#{app_js_path}/application_visit.js"
 


### PR DESCRIPTION
This PR migrates most actions over to `createAction`. The goal of this is
1. Better typescript support using `.match` which allows us to use a [typescript guard](https://redux-toolkit.js.org/api/createAction#as-a-typescript-type-guard)
2. Easier for users. We previously exposed the const to the user so that they can createAction themselves before using it in a slice. Now they can just import it. For example:

```js
import { createSlice } from '@reduxjs/toolkit'
import { saveResponse, beforeVisit } from '@thoughtbot/superglue'

export const flashSlice = createSlice({
  name: 'flash',
  initialState: {},
  extraReducers: (builder) => {
    builder.addCase(beforeVisit, (state, action) => {
      return {}
    })
    builder.addCase(saveResponse, (state, action) => {
      const { page } = action.payload;

      return {
        ...state, ...page.slices.flash
      }
    })
  }
})

```