### PR TITLE
Manually trigger doc publishing

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,9 +1,5 @@
 name: Publish docs
-on:
-  push:
-    branches:
-      - main
-    workflow_dispatch:
+on: workflow_dispatch
 
 permissions:
   contents: write


### PR DESCRIPTION
This is so we can work on 1.0 without affecting the existing docs.