### PR TITLE
Remove navigation on same page

### DIFF
--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -190,6 +190,13 @@ export const visit: VisitCreator = (
         if (!rsp.redirected && !isGet) {
           meta.suggestedAction = 'replace'
         }
+        pageKey = urlToPageKey(rsp.url)
+
+        const isSamePage = pageKey == currentPageKey
+
+        if (isSamePage) {
+          meta.suggestedAction = 'none'
+        }
 
         if (revisit && isGet) {
           if (rsp.redirected) {
@@ -198,8 +205,6 @@ export const visit: VisitCreator = (
             meta.suggestedAction = 'none'
           }
         }
-
-        pageKey = urlToPageKey(rsp.url)
 
         if (!isGet && !rsp.redirected) {
           pageKey = currentPageKey

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -24,7 +24,10 @@ export type PageKey = string
  *
  * When the page already exists in the store:
  * - `fromCacheOnly` - Use the cached page that exists on the store, only.
- * - `revisitOnly` - Ignore the cache and make a request for the latest page.
+ * - `revisitOnly` - Ignore the cache and make a request for the latest page. If
+ * the response was 200, the {@link SuggestedAction} would be `none` as we don't want
+ * to push into history. If the response was redirected, the {@link SuggestedAction} would be set to
+ * `replace`.
  * - `fromCacheAndRevisitInBackground` - Use the cache version of the page so
  *    superglue can optimistically navigate to it, then make an additional request
  *    for the latest version.

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -1282,6 +1282,25 @@ Consider using data-sg-visit, the visit function, or redirect_back.`
       })
     })
 
+    it('returns a meta with suggestedAction of "none" if the next page has the same pageKey as the current page', () => {
+      const initialState = {
+        pages: {},
+        superglue: {
+          assets: [],
+          currentPageKey: '/same_page',
+        },
+      }
+
+      const store = mockStore(initialState)
+
+      fetchMock.mock('/same_page?format=json', rsp.visitSuccess())
+
+      return store.dispatch(visit('/same_page')).then((meta) => {
+        expect(meta.redirected).toEqual(false)
+        expect(meta.suggestedAction).toEqual('none')
+      })
+    })
+
     it('gets aborted when a new visit starts', () =>
       new Promise((done) => {
         const initialState = {


### PR DESCRIPTION
This adjusts the suggestedAction logic to set to `none` if we click on a link that leads to the same page that you are currently on.