### PR TITLE
Raise on mismatched components instead of warn

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -65,9 +65,17 @@ sequenceDiagram
   end
 ```
 
-If you provide a `pageKey` you can also target a different page
-in your store not visible to the user.
+If you provide a `pageKey` you can also target a different page in your store
+not visible to the user. Unlike `visit`, `remote` will not derive the target
+page key from the response. As long as the componentIdentifier from the
+response and target page is the same, `remote` will save and process the response
+to the provided `pageKey`.
 
+!!! warning
+    The componentIdentifier from the page response **MUST** match the target page, otherwise
+    remote will throw a `MismatchedComponentError` error. You can override this by using the
+    `force: true` option. See the [docs](reference/types.requests.md#remoteprops)
+    for details.
 
 ```mermaid
 sequenceDiagram

--- a/superglue/lib/types/requests.ts
+++ b/superglue/lib/types/requests.ts
@@ -83,6 +83,11 @@ export interface RemoteProps extends BaseProps {
    * {@link Remote} will use the `currentPageKey` at {@link SuperglueState}
    */
   pageKey?: PageKey
+  /**
+   * Forces {@link Remote} to allow mismatched components between the response
+   * and the target page.
+   */
+  force?: boolean
 }
 
 export interface BeforeSave {

--- a/superglue/spec/features/navigation.spec.jsx
+++ b/superglue/spec/features/navigation.spec.jsx
@@ -650,7 +650,10 @@ describe('navigation', () => {
       )
       const store = instance.store
 
-      const mockResponse = rsp.graftSuccessWithNewZip()
+      const mockResponse = rsp.graftSuccessWithNewZip({
+        componentIdentifier: 'home',
+      })
+
       mockResponse.headers['x-response-url'] = '/about'
       fetchMock.mock(
         'http://example.com/about?props_at=address&format=json',

--- a/superglue/spec/fixtures.js
+++ b/superglue/spec/fixtures.js
@@ -14,7 +14,7 @@ export const visitSuccess = () => {
   }
 }
 
-export const graftSuccessWithNewZip = () => {
+export const graftSuccessWithNewZip = (body) => {
   return {
     body: JSON.stringify({
       data: { zip: 91210 },
@@ -23,6 +23,7 @@ export const graftSuccessWithNewZip = () => {
       csrfToken: 'token',
       assets: ['application-new123.js', 'application-new123.js'],
       fragments: [],
+      ...body,
     }),
     headers: {
       'content-type': 'application/json',


### PR DESCRIPTION
This changes `remote` to raise when encountering a page response that has a different component than the target page to save in. We also add a `force: true` option to remote to retain the original behavior.