### PR TITLE
Default remote to a calculated key

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -56,8 +56,7 @@ as you want.
     Its possible to modify the remote payload before it saves
     to the store. See the [beforeSave](reference/types.requests.md#remoteprops) callback.
 
-By default, `remote` saves or updates the response to the current page that the
-user is seeing. At glance it looks like this:
+At glance it looks like this:
 
 ```mermaid
 sequenceDiagram
@@ -68,18 +67,17 @@ sequenceDiagram
     Superglue -->> Server: Re-request with format JSON `/posts/new.json`
     activate Server
     Server -->> Superglue: `/posts/new.json` response
-    Superglue -->> Superglue: Save response or update current page
+    Superglue -->> Superglue: Save response
     Superglue -->> Browser: User on current page sees update
     deactivate Server
     deactivate Superglue
   end
 ```
 
-If you provide a `pageKey` you can also target a different page in your store
-not visible to the user. Unlike `visit`, `remote` will not derive the target
-page key from the response. As long as the componentIdentifier from the
-response and target page is the same, `remote` will save and process the response
-to the provided `pageKey`.
+By default, `remote` derives a `pagekey` from the response to save the page.
+You can override this behavior and expliclity pass a `pageKey` option to target
+a different page in the store. If the user is not viewing the target page, they
+will not see an update.
 
 !!! warning
     The componentIdentifier from the page response **MUST** match the target page, otherwise
@@ -116,6 +114,10 @@ sequenceDiagram
 
 ## Differences from UJS
 
-Superglue UJS selectively exposes options of `visit` and `remote` as data
-attribute and is architected for forms and links. The `visit` and `remote`
-thunks are functions that return promises, allowing for greater flexibility.
+The `visit` and `remote` thunks are functions that return promises, allowing
+for greater flexibility. Superglue UJS selectively exposes options of `visit`
+and `remote` for easy dev exp when using with forms and links.
+
+!!! hint
+    Unlike `remote`, `data-sg-remote` does not derive the `pageKey`. Instead it
+    saves or grafts all page responses to current page.

--- a/docs/ujs.md
+++ b/docs/ujs.md
@@ -73,9 +73,15 @@ tabs, notifications, etc.
 
 ## `data-sg-remote`
 
-Use `data-sg-remote` when you want to update parts of the current page without
-reloading the screen. You'd can use this with props_template's [digging]
-to selectively load content.
+Use `data-sg-remote` when you want to update parts of the **current page** without
+reloading the screen.
+
+<div class="grid cards" markdown>
+  -  [:octicons-arrow-right-24: See differences](requests.md#differences-from-ujs)
+     from `remote`
+</div>
+
+Combine this with props_template's [digging] to selectively load content.
 
 ```jsx
 <a href='/posts?page_num=2&props_at=data.body.postsList' data-sg-remote/>
@@ -91,3 +97,4 @@ You can also use `data-sg-remote` on forms.
   ....
 </form>
 ```
+

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -80,23 +80,17 @@ sure you want to proceed, use force: true.
 export const remote: RemoteCreator = (
   path,
   {
-    method = 'GET',
-    headers,
-    body,
     pageKey: targetPageKey,
     force = false,
     beforeSave = (prevPage: Page, receivedPage: PageResponse) => receivedPage,
+    ...rest
   } = {}
 ) => {
   path = withoutBusters(path)
   targetPageKey = targetPageKey && urlToPageKey(targetPageKey)
 
   return (dispatch, getState) => {
-    const fetchArgs = argsForFetch(getState, path, {
-      method,
-      headers,
-      body,
-    })
+    const fetchArgs = argsForFetch(getState, path, rest)
     const currentPageKey = getState().superglue.currentPageKey
 
     dispatch(beforeRemote({ currentPageKey, fetchArgs }))
@@ -143,12 +137,10 @@ let lastVisitController = {
 export const visit: VisitCreator = (
   path,
   {
-    method = 'GET',
-    headers,
-    body,
     placeholderKey,
     beforeSave = (prevPage: Page, receivedPage: PageResponse) => receivedPage,
     revisit = false,
+    ...rest
   } = {}
 ) => {
   path = withoutBusters(path)
@@ -176,9 +168,7 @@ export const visit: VisitCreator = (
     const controller = new AbortController()
     const { signal } = controller
     const fetchArgs = argsForFetch(getState, path, {
-      headers,
-      body,
-      method,
+      ...rest,
       signal,
     })
 

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -197,7 +197,7 @@ const Application = forwardRef(function Application(
     visit,
     remote,
     ujsAttributePrefix: 'data-sg',
-    store
+    store,
   })
 
   useEffect(() => {

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -197,6 +197,7 @@ const Application = forwardRef(function Application(
     visit,
     remote,
     ujsAttributePrefix: 'data-sg',
+    store
   })
 
   useEffect(() => {

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -335,10 +335,12 @@ export type UJSHandlers = ({
   ujsAttributePrefix,
   visit,
   remote,
+  store,
 }: {
   ujsAttributePrefix: string
   visit: Visit
   remote: Remote
+  store: SuperglueStore
 }) => Handlers
 
 /**

--- a/superglue/lib/types/requests.ts
+++ b/superglue/lib/types/requests.ts
@@ -27,7 +27,7 @@ export interface Visit {
 /**
  * Options for Visit
  */
-export interface VisitProps extends BaseProps {
+export interface VisitProps extends Omit<BaseProps, 'signal'> {
   /**
    * When present, Superglue will use the page state located at that pageKey and
    * optimistally navigates to it as the next page's state while the requests
@@ -62,7 +62,7 @@ export interface Remote {
 /**
  * Basic options shared betwen {@link VisitProps} and {@link RemoteProps}
  */
-interface BaseProps {
+interface BaseProps extends RequestInit {
   /** The HTTP method */
   method?: string
   /** The HTTP body */

--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -63,7 +63,13 @@ export function handleServerErrors(args: ParsedResponse): ParsedResponse {
 export function argsForFetch(
   getState: () => RootState,
   pathQuery: string,
-  { method = 'GET', headers = {}, body = '', signal }: BasicRequestInit = {}
+  {
+    method = 'GET',
+    headers = {},
+    body = '',
+    signal,
+    ...rest
+  }: BasicRequestInit = {}
 ): [string, BasicRequestInit] {
   method = method.toUpperCase()
   const currentState = getState().superglue
@@ -130,7 +136,7 @@ export function argsForFetch(
     delete options.body
   }
 
-  return [fetchPath.toString(), options]
+  return [fetchPath.toString(), { ...options, ...rest }]
 }
 
 export function extractJSON(rsp: Response): PromiseLike<ParsedResponse> {

--- a/superglue/lib/utils/ujs.ts
+++ b/superglue/lib/utils/ujs.ts
@@ -7,24 +7,29 @@ import {
   Meta,
   Handlers,
   UJSHandlers,
+  SuperglueStore,
 } from '../types'
 
 export class HandlerBuilder {
   public attributePrefix: string
   public visit: Visit
   public remote: Remote
+  private store: SuperglueStore
 
   constructor({
     ujsAttributePrefix,
     visit,
     remote,
+    store,
   }: {
     ujsAttributePrefix: string
     visit: Visit
     remote: Remote
+    store: SuperglueStore
   }) {
     this.attributePrefix = ujsAttributePrefix
     this.isUJS = this.isUJS.bind(this)
+    this.store = store
 
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleClick = this.handleClick.bind(this)
@@ -123,7 +128,8 @@ export class HandlerBuilder {
     }
 
     if (linkOrForm.getAttribute(this.attributePrefix + '-remote')) {
-      return this.remote(url, opts)
+      const { currentPageKey } = this.store.getState().superglue
+      return this.remote(url, { ...opts, pageKey: currentPageKey })
     }
   }
 
@@ -139,11 +145,13 @@ export const ujsHandlers: UJSHandlers = ({
   ujsAttributePrefix,
   visit,
   remote,
+  store,
 }) => {
   const builder = new HandlerBuilder({
     visit,
     remote,
     ujsAttributePrefix,
+    store,
   })
 
   return builder.handlers()

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -878,7 +878,7 @@ describe('action creators', () => {
           expect(allSuperglueActions(store)).toEqual(expectedActions)
         })
     })
-    
+
     it('defaults to the response url as the pageKey on GET requests', () => {
       const store = buildStore({
         superglue: {

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -878,8 +878,34 @@ describe('action creators', () => {
           expect(allSuperglueActions(store)).toEqual(expectedActions)
         })
     })
+    
+    it('defaults to the response url as the pageKey on GET requests', () => {
+      const store = buildStore({
+        superglue: {
+          currentPageKey: '/current_url',
+          csrfToken: 'token',
+        },
+      })
 
-    it('defaults to the currentPageKey as the pageKey', () => {
+      fetchMock.mock('/foobar?format=json', {
+        body: successfulBody(),
+        headers: {
+          'content-type': 'application/json',
+        },
+      })
+
+      return store
+        .dispatch(remote('/foobar', { method: 'GET' }))
+        .then((meta) => {
+          expect(meta).toEqual(
+            expect.objectContaining({
+              pageKey: '/foobar',
+            })
+          )
+        })
+    })
+
+    it('defaults to the currentPageKey as the pageKey when a non GET renders', () => {
       const store = buildStore({
         superglue: {
           currentPageKey: '/current_url',
@@ -905,7 +931,7 @@ describe('action creators', () => {
         })
     })
 
-    it('uses the pageKey option to override the currentPageKey as the preferred pageKey', () => {
+    it('uses the pageKey option to explicitly specify where to store the response', () => {
       const store = buildStore({
         superglue: {
           currentPageKey: '/url_to_be_overridden',
@@ -1464,16 +1490,16 @@ describe('action creators', () => {
 
         const expectedActions = [
           {
-            type: '@@superglue/COPY_PAGE',
-            payload: { from: '/current', to: '/details' },
-          },
-          {
             type: '@@superglue/BEFORE_VISIT',
             payload: expect.any(Object),
           },
           {
             type: '@@superglue/BEFORE_FETCH',
             payload: expect.any(Object),
+          },
+          {
+            type: '@@superglue/COPY_PAGE',
+            payload: { from: '/current', to: '/details' },
           },
           {
             type: '@@superglue/HANDLE_GRAFT',

--- a/superglue/spec/lib/utils/ujs.spec.js
+++ b/superglue/spec/lib/utils/ujs.spec.js
@@ -59,18 +59,12 @@ describe('ujs', () => {
     it('calls visit on a valid link', () => {
       const ujsAttributePrefix = 'data'
       const visit = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
-        },
-      }
       const store = {}
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         store,
         visit,
-        navigatorRef,
       })
 
       const fakeEvent = createFakeEvent()
@@ -83,11 +77,6 @@ describe('ujs', () => {
     it('calls visit with a placeholder when props_at is present on a valid link', () => {
       const ujsAttributePrefix = 'data'
       const visit = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
-        },
-      }
       const store = {
         getState: () => {
           return {
@@ -102,7 +91,6 @@ describe('ujs', () => {
         ujsAttributePrefix,
         store,
         visit,
-        navigatorRef,
       })
 
       const { onClick } = builder.handlers()
@@ -117,41 +105,37 @@ describe('ujs', () => {
     it('calls remote if a link is enabled with remote', () => {
       const ujsAttributePrefix = 'data'
       const remote = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
+      const store = {
+        getState: () => {
+          return {
+            superglue: {
+              currentPageKey: '/current',
+            },
+          }
         },
       }
-      const store = {}
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         store,
         remote,
-        navigatorRef,
       })
 
       const { onClick } = builder.handlers()
       onClick(createFakeRemoteEvent())
 
-      expect(remote).toHaveBeenCalledWith('/foo', { method: 'GET' })
+      expect(remote).toHaveBeenCalledWith('/foo', { method: 'GET' , pageKey: "/current"})
     })
 
     it('does not call visit on an link does not have the visit attribute data-visit', () => {
       const store = {}
       const ujsAttributePrefix = 'data'
       const visit = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
-        },
-      }
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         store,
         visit,
-        navigatorRef,
       })
 
       const fakeEvent = createFakeEvent()
@@ -171,17 +155,11 @@ describe('ujs', () => {
       const store = {}
       const ujsAttributePrefix = 'data'
       const visit = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
-        },
-      }
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         visit,
         store,
-        navigatorRef,
       })
 
       const { onClick } = builder.handlers()
@@ -267,17 +245,11 @@ describe('ujs', () => {
       const store = {}
       const ujsAttributePrefix = 'data'
       const visit = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
-        },
-      }
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         visit,
         store,
-        navigatorRef,
       })
       global.FormData = () => {}
       vi.spyOn(global, 'FormData').mockImplementation(() => ({ some: 'Body' }))
@@ -294,20 +266,22 @@ describe('ujs', () => {
     })
 
     it('succssfully posts a form with a remote attribute', () => {
-      const store = {}
-      const ujsAttributePrefix = 'data'
-      const remote = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
+      const store = {
+        getState: () => {
+          return {
+            superglue: {
+              currentPageKey: '/current',
+            },
+          }
         },
       }
+      const ujsAttributePrefix = 'data'
+      const remote = vi.fn()
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         store,
         remote,
-        navigatorRef,
       })
       global.FormData = () => {}
       vi.spyOn(global, 'FormData').mockImplementation(() => ({ some: 'Body' }))
@@ -319,6 +293,7 @@ describe('ujs', () => {
       expect(global.FormData).toHaveBeenCalledWith(fakeFormEvent.target)
       expect(remote).toHaveBeenCalledWith('/foo', {
         method: 'POST',
+        pageKey: "/current",
         body: { some: 'Body' },
       })
     })
@@ -327,17 +302,11 @@ describe('ujs', () => {
       const store = {}
       const ujsAttributePrefix = 'data'
       const visit = vi.fn()
-      const navigatorRef = {
-        current: {
-          navigateTo: () => {},
-        },
-      }
 
       const builder = new HandlerBuilder({
         ujsAttributePrefix,
         store,
         visit,
-        navigatorRef,
       })
       global.FormData = () => {}
       vi.spyOn(global, 'FormData').mockImplementation(() => ({ some: 'Body' }))

--- a/superglue/spec/lib/utils/ujs.spec.js
+++ b/superglue/spec/lib/utils/ujs.spec.js
@@ -124,7 +124,10 @@ describe('ujs', () => {
       const { onClick } = builder.handlers()
       onClick(createFakeRemoteEvent())
 
-      expect(remote).toHaveBeenCalledWith('/foo', { method: 'GET' , pageKey: "/current"})
+      expect(remote).toHaveBeenCalledWith('/foo', {
+        method: 'GET',
+        pageKey: '/current',
+      })
     })
 
     it('does not call visit on an link does not have the visit attribute data-visit', () => {
@@ -293,7 +296,7 @@ describe('ujs', () => {
       expect(global.FormData).toHaveBeenCalledWith(fakeFormEvent.target)
       expect(remote).toHaveBeenCalledWith('/foo', {
         method: 'POST',
-        pageKey: "/current",
+        pageKey: '/current',
         body: { some: 'Body' },
       })
     })


### PR DESCRIPTION
    This makes remote derive the target page key just like visit instead of
    defaulting to the current key. It enables a far nicer dev ex when using
    remote outside of ujs.

    However when using data-sg-remote, we default to the current pagekey just
    like before. Its better dev ex when using remote in UJS.