### PR TITLE
Fix dedup URL params

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -1,5 +1,4 @@
-import { urlToPageKey, getIn } from '../utils'
-import parse from 'url-parse'
+import { urlToPageKey, getIn, propsAtParam } from '../utils'
 import {
   saveResponse,
   GRAFTING_ERROR,
@@ -31,11 +30,9 @@ function fetchDeferments(
         successAction = GRAFTING_SUCCESS,
         failAction = GRAFTING_ERROR,
       }) {
-        const parsedUrl = new parse(url, true)
-
         // props_at will always be present in a graft response
         // That's why this is marked `as string`
-        const keyPath = parsedUrl.query.props_at as string
+        const keyPath = propsAtParam(url) as string
 
         return dispatch(remote(url, { pageKey }))
           .then(() => {

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -3,7 +3,6 @@ import {
   parseResponse,
   needsRefresh,
   urlToPageKey,
-  withoutBusters,
   hasPropsAt,
   propsAtParam,
   removePropsAt,
@@ -76,7 +75,6 @@ export const remote: RemoteCreator = (
     ...rest
   } = {}
 ) => {
-  path = withoutBusters(path)
   targetPageKey = targetPageKey && urlToPageKey(targetPageKey)
 
   return (dispatch, getState) => {
@@ -146,8 +144,6 @@ export const visit: VisitCreator = (
     ...rest
   } = {}
 ) => {
-  path = withoutBusters(path)
-
   return (dispatch, getState) => {
     const currentPageKey = getState().superglue.currentPageKey
     placeholderKey =

--- a/superglue/lib/components/Navigation.tsx
+++ b/superglue/lib/components/Navigation.tsx
@@ -6,7 +6,7 @@ import React, {
   useImperativeHandle,
   ForwardedRef,
 } from 'react'
-import { urlToPageKey, pathWithoutBZParams } from '../utils'
+import { urlToPageKey } from '../utils'
 import { removePage, setActivePage } from '../actions'
 import {
   HistoryState,
@@ -164,7 +164,6 @@ const NavigationProvider = forwardRef(function NavigationProvider(
       return false
     }
 
-    path = pathWithoutBZParams(path)
     const nextPageKey = urlToPageKey(path)
     const hasPage = Object.prototype.hasOwnProperty.call(
       store.getState().pages,

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -1,5 +1,4 @@
 import React, { useRef, useMemo } from 'react'
-import parse from 'url-parse'
 import { config } from './config'
 import { urlToPageKey, ujsHandlers, argsForHistory } from './utils'
 import { saveAndProcessPage } from './action_creators'
@@ -53,8 +52,7 @@ export const prepareStore = (
   initialPage: VisitResponse,
   path: string
 ) => {
-  const location = parse(path)
-  const initialPageKey = urlToPageKey(location.href)
+  const initialPageKey = urlToPageKey(path)
   const { csrfToken } = initialPage
 
   store.dispatch(
@@ -83,7 +81,7 @@ export const setup = ({
 
   const { visit, remote } = buildVisitAndRemote(navigatorRef, store)
 
-  const initialPageKey = urlToPageKey(parse(path).href)
+  const initialPageKey = urlToPageKey(path)
   const nextHistory = history || createHistory()
   nextHistory.replace(...argsForHistory(path))
   prepareStore(store, initialPage, path)

--- a/superglue/lib/utils/ujs.ts
+++ b/superglue/lib/utils/ujs.ts
@@ -1,4 +1,3 @@
-import { withoutBusters } from './url'
 import {
   Handlers,
   UJSHandlers,
@@ -77,13 +76,12 @@ export class HandlerBuilder {
 
     event.preventDefault()
 
-    let url = form.getAttribute('action')
+    const url = form.getAttribute('action')
     if (!url) {
       return
     }
 
     const method = (form.getAttribute('method') || 'POST').toUpperCase()
-    url = withoutBusters(url)
 
     this.visitOrRemote(form, url, {
       method,
@@ -103,11 +101,10 @@ export class HandlerBuilder {
     }
 
     event.preventDefault()
-    let url = link.getAttribute('href')
+    const url = link.getAttribute('href')
     if (!url) {
       return
     }
-    url = withoutBusters(url)
 
     this.visitOrRemote(link, url, { method: 'GET' })
   }

--- a/superglue/package.json
+++ b/superglue/package.json
@@ -50,7 +50,6 @@
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.10.1",
-    "@types/url-parse": "^1.4.11",
     "@typescript-eslint/eslint-plugin": "^7.15.0",
     "@typescript-eslint/parser": "^7.15.0",
     "@vitejs/plugin-react": "^4.3.1",
@@ -79,12 +78,11 @@
     "vitest": "^2.0.2"
   },
   "peerDependencies": {
+    "@reduxjs/toolkit": "^2.2.8",
     "react": "^18 || ^19",
-    "react-redux": "^9 || ^8",
-    "@reduxjs/toolkit": "^2.2.8"
+    "react-redux": "^9 || ^8"
   },
   "dependencies": {
-    "history": "^5.3.0",
-    "url-parse": "^1.5.1"
+    "history": "^5.3.0"
   }
 }

--- a/superglue/spec/helpers/polyfill.js
+++ b/superglue/spec/helpers/polyfill.js
@@ -1,5 +1,4 @@
 import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill'
-import { TextEncoder, TextDecoder } from 'util'
 import { JSDOM } from 'jsdom'
 
 function setUpDomEnvironment() {
@@ -26,5 +25,3 @@ function copyProps(src, target) {
 setUpDomEnvironment()
 
 global.AbortController = AbortController
-global.TextEncoder = TextEncoder
-global.TextDecoder = TextDecoder

--- a/superglue/spec/helpers/setup.js
+++ b/superglue/spec/helpers/setup.js
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom/vitest'
+import { vi } from 'vitest'
+
+vi.mock(import('../../lib/config.ts'), () => {
+  return {
+    config: {
+      baseUrl: 'https://example.com',
+      maxPages: 20,
+    },
+  }
+})

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -198,7 +198,7 @@ describe('action creators', () => {
         },
       ]
 
-      fetchMock.mock('/foo?props_at=body&format=json', {
+      fetchMock.mock('https://example.com/foo?props_at=body&format=json', {
         body: JSON.stringify({
           data: 'success',
           action: 'graft',
@@ -245,7 +245,7 @@ describe('action creators', () => {
         ],
       }
 
-      fetchMock.mock('/foo?props_at=data.body&format=json', {
+      fetchMock.mock('https://example.com/foo?props_at=data.body&format=json', {
         body: JSON.stringify({
           data: {
             aside: {
@@ -264,45 +264,51 @@ describe('action creators', () => {
         },
       })
 
-      fetchMock.mock('/foo?props_at=data.body.aside.top&format=json', {
-        body: JSON.stringify({
-          data: {
-            greeting: {
-              hello: 'world',
+      fetchMock.mock(
+        'https://example.com/foo?props_at=data.body.aside.top&format=json',
+        {
+          body: JSON.stringify({
+            data: {
+              greeting: {
+                hello: 'world',
+              },
             },
+            action: 'graft',
+            path: 'data.body.aside.top',
+            csrfToken: 'token',
+            fragments: [
+              { type: 'greeting', path: 'data.body.aside.top.greeting' },
+            ],
+            assets: [],
+            defers: [],
+          }),
+          headers: {
+            'content-type': 'application/json',
           },
-          action: 'graft',
-          path: 'data.body.aside.top',
-          csrfToken: 'token',
-          fragments: [
-            { type: 'greeting', path: 'data.body.aside.top.greeting' },
-          ],
-          assets: [],
-          defers: [],
-        }),
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
+        }
+      )
 
-      fetchMock.mock('/foo?props_at=data.footer&format=json', {
-        body: JSON.stringify({
-          data: {
-            copyright: {
-              author: 'john',
+      fetchMock.mock(
+        'https://example.com/foo?props_at=data.footer&format=json',
+        {
+          body: JSON.stringify({
+            data: {
+              copyright: {
+                author: 'john',
+              },
             },
+            action: 'graft',
+            path: 'data.footer',
+            csrfToken: 'token',
+            fragments: [{ type: 'copyright', path: 'data.footer.copyright' }],
+            assets: [],
+            defers: [],
+          }),
+          headers: {
+            'content-type': 'application/json',
           },
-          action: 'graft',
-          path: 'data.footer',
-          csrfToken: 'token',
-          fragments: [{ type: 'copyright', path: 'data.footer.copyright' }],
-          assets: [],
-          defers: [],
-        }),
-        headers: {
-          'content-type': 'application/json',
-        },
-      })
+        }
+      )
 
       const expectedActions = [
         {
@@ -483,7 +489,7 @@ describe('action creators', () => {
         },
       ]
 
-      fetchMock.mock('/foo?props_at=body&format=json', {
+      fetchMock.mock('https://example.com/foo?props_at=body&format=json', {
         body: JSON.stringify({
           data: 'success',
           action: 'graft',
@@ -677,7 +683,10 @@ describe('action creators', () => {
         },
       ]
 
-      fetchMock.mock('/some_defered_request?props_at=body&format=json', 500)
+      fetchMock.mock(
+        'https://example.com/some_defered_request?props_at=body&format=json',
+        500
+      )
 
       return store.dispatch(saveAndProcessPage('/foo', page)).then(() => {
         expect(allSuperglueActions(store)).toEqual(expectedActions)
@@ -737,7 +746,10 @@ describe('action creators', () => {
         },
       ]
 
-      fetchMock.mock('/some_defered_request?props_at=body&format=json', 500)
+      fetchMock.mock(
+        'https://example.com/some_defered_request?props_at=body&format=json',
+        500
+      )
 
       return store.dispatch(saveAndProcessPage('/foo', page)).then(() => {
         expect(allSuperglueActions(store)).toEqual(expectedActions)
@@ -754,7 +766,7 @@ describe('action creators', () => {
     it('fetches with correct headers and fires SAVE_RESPONSE', () => {
       const store = buildStore(initialState())
 
-      fetchMock.mock('/foo?format=json', {
+      fetchMock.mock('https://example.com/foo?format=json', {
         body: successfulBody(),
         headers: {
           'content-type': 'application/json',
@@ -766,12 +778,20 @@ describe('action creators', () => {
           type: '@@superglue/BEFORE_REMOTE',
           payload: {
             currentPageKey: '/bar',
-            fetchArgs: ['/foo?format=json', expect.any(Object)],
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
           },
         },
         {
           type: '@@superglue/BEFORE_FETCH',
-          payload: { fetchArgs: ['/foo?format=json', expect.any(Object)] },
+          payload: {
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
+          },
         },
         {
           type: '@@superglue/SAVE_RESPONSE',
@@ -789,7 +809,9 @@ describe('action creators', () => {
       ]
 
       return store.dispatch(remote('/foo', { pageKey: '/foo' })).then(() => {
-        const requestheaders = fetchMock.lastCall('/foo?format=json')[1].headers
+        const requestheaders = fetchMock.lastCall(
+          'https://example.com/foo?format=json'
+        )[1].headers
 
         expect(requestheaders).toEqual({
           accept: 'application/json',
@@ -829,7 +851,7 @@ describe('action creators', () => {
         defers: [],
       }
 
-      fetchMock.mock('/foo?format=json', {
+      fetchMock.mock('https://example.com/foo?format=json', {
         body,
         headers: {
           'content-type': 'application/json',
@@ -842,12 +864,20 @@ describe('action creators', () => {
           type: '@@superglue/BEFORE_REMOTE',
           payload: {
             currentPageKey: '/bar',
-            fetchArgs: ['/foo?format=json', expect.any(Object)],
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
           },
         },
         {
           type: '@@superglue/BEFORE_FETCH',
-          payload: { fetchArgs: ['/foo?format=json', expect.any(Object)] },
+          payload: {
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
+          },
         },
         {
           type: '@@superglue/SAVE_RESPONSE',
@@ -887,7 +917,7 @@ describe('action creators', () => {
         },
       })
 
-      fetchMock.mock('/foobar?format=json', {
+      fetchMock.mock('https://example.com/foobar?format=json', {
         body: successfulBody(),
         headers: {
           'content-type': 'application/json',
@@ -913,7 +943,7 @@ describe('action creators', () => {
         },
       })
 
-      fetchMock.mock('/foobar?format=json', {
+      fetchMock.mock('https://example.com/foobar?format=json', {
         body: successfulBody(),
         headers: {
           'content-type': 'application/json',
@@ -939,7 +969,7 @@ describe('action creators', () => {
         },
       })
 
-      fetchMock.mock('/foobar?format=json', {
+      fetchMock.mock('https://example.com/foobar?format=json', {
         body: successfulBody(),
         headers: {
           'content-type': 'application/json',
@@ -966,7 +996,10 @@ describe('action creators', () => {
       new Promise((done) => {
         const store = buildStore(initialState())
 
-        fetchMock.mock('/first?props_at=foo&format=json', rsp.visitSuccess())
+        fetchMock.mock(
+          'https://example.com/first?props_at=foo&format=json',
+          rsp.visitSuccess()
+        )
         store.dispatch(remote('/first?props_at=foo')).then((meta) => {
           done()
         })
@@ -975,7 +1008,7 @@ describe('action creators', () => {
     it('returns a meta with redirected true if was redirected', () => {
       const store = buildStore(initialState())
 
-      fetchMock.mock('/redirecting_url?format=json', {
+      fetchMock.mock('https://example.com/redirecting_url?format=json', {
         status: 200,
         redirectUrl: '/foo',
         headers: {
@@ -992,19 +1025,30 @@ describe('action creators', () => {
 
     it('fires SUPERGLUE_REQUEST_ERROR on a bad server response status', () => {
       const store = buildStore(initialState())
-      fetchMock.mock('/foo?format=json', { body: '{}', status: 500 })
+      fetchMock.mock('https://example.com/foo?format=json', {
+        body: '{}',
+        status: 500,
+      })
 
       const expectedActions = [
         {
           type: '@@superglue/BEFORE_REMOTE',
           payload: {
             currentPageKey: '/bar',
-            fetchArgs: ['/foo?format=json', expect.any(Object)],
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
           },
         },
         {
           type: '@@superglue/BEFORE_FETCH',
-          payload: { fetchArgs: ['/foo?format=json', expect.any(Object)] },
+          payload: {
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
+          },
         },
         {
           type: '@@superglue/ERROR',
@@ -1024,7 +1068,7 @@ describe('action creators', () => {
 
     it('fires SUPERGLUE_REQUEST_ERROR on a invalid response', () => {
       const store = buildStore(initialState())
-      fetchMock.mock('/foo?format=json', {
+      fetchMock.mock('https://example.com/foo?format=json', {
         status: 200,
         headers: {
           'content-type': 'text/bad',
@@ -1037,25 +1081,33 @@ describe('action creators', () => {
           type: '@@superglue/BEFORE_REMOTE',
           payload: {
             currentPageKey: '/bar',
-            fetchArgs: ['/foo?format=json', expect.any(Object)],
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
           },
         },
         {
           type: '@@superglue/BEFORE_FETCH',
-          payload: { fetchArgs: ['/foo?format=json', expect.any(Object)] },
+          payload: {
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
+          },
         },
         {
           type: '@@superglue/ERROR',
           payload: {
             message:
-              'invalid json response body at /foo?format=json reason: Unexpected end of JSON input',
+              'invalid json response body at https://example.com/foo?format=json reason: Unexpected end of JSON input',
           },
         },
       ]
 
       return store.dispatch(remote('/foo')).catch((err) => {
         expect(err.message).toEqual(
-          'invalid json response body at /foo?format=json reason: Unexpected end of JSON input'
+          'invalid json response body at https://example.com/foo?format=json reason: Unexpected end of JSON input'
         )
         expect(err.response.status).toEqual(200)
         expect(allSuperglueActions(store)).toEqual(
@@ -1067,7 +1119,7 @@ describe('action creators', () => {
     it('fires SUPERGLUE_REQUEST_ERROR when the SJR returns nothing', () => {
       const store = buildStore(initialState())
 
-      fetchMock.mock('/foo?format=json', {
+      fetchMock.mock('https://example.com/foo?format=json', {
         body: ``,
         headers: {
           'content-type': 'application/json',
@@ -1079,25 +1131,33 @@ describe('action creators', () => {
           type: '@@superglue/BEFORE_REMOTE',
           payload: {
             currentPageKey: '/bar',
-            fetchArgs: ['/foo?format=json', expect.any(Object)],
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
           },
         },
         {
           type: '@@superglue/BEFORE_FETCH',
-          payload: { fetchArgs: ['/foo?format=json', expect.any(Object)] },
+          payload: {
+            fetchArgs: [
+              'https://example.com/foo?format=json',
+              expect.any(Object),
+            ],
+          },
         },
         {
           type: '@@superglue/ERROR',
           payload: {
             message:
-              'invalid json response body at /foo?format=json reason: Unexpected end of JSON input',
+              'invalid json response body at https://example.com/foo?format=json reason: Unexpected end of JSON input',
           },
         },
       ]
 
       return store.dispatch(remote('/foo')).catch((err) => {
         expect(err.message).toEqual(
-          'invalid json response body at /foo?format=json reason: Unexpected end of JSON input'
+          'invalid json response body at https://example.com/foo?format=json reason: Unexpected end of JSON input'
         )
         expect(err.response.status).toEqual(200)
         expect(allSuperglueActions(store)).toEqual(
@@ -1119,7 +1179,7 @@ describe('action creators', () => {
             },
           },
         })
-        fetchMock.mock('/foo?format=json', {
+        fetchMock.mock('https://example.com/foo?format=json', {
           body: JSON.stringify({
             data: 'success',
             action: 'graft',
@@ -1183,7 +1243,7 @@ describe('action creators', () => {
         fragments: [],
       }
 
-      fetchMock.mock('/bar?format=json', {
+      fetchMock.mock('https://example.com/bar?format=json', {
         body: successfulBody,
         headers: {
           'content-type': 'application/json',
@@ -1218,7 +1278,7 @@ describe('action creators', () => {
         fragments: [],
       }
 
-      fetchMock.mock('/bar?format=json', {
+      fetchMock.mock('https://example.com/bar?format=json', {
         body: successfulBody,
         headers: {
           'content-type': 'application/json',
@@ -1258,7 +1318,7 @@ describe('action creators', () => {
         fragments: [],
       }
 
-      fetchMock.mock('/bar?format=json', {
+      fetchMock.mock('https://example.com/bar?format=json', {
         body: successfulBody,
         headers: {
           'content-type': 'application/json',
@@ -1288,7 +1348,10 @@ describe('action creators', () => {
 
         const store = buildStore(initialState)
 
-        fetchMock.mock('/first?format=json', rsp.visitSuccess())
+        fetchMock.mock(
+          'https://example.com/first?format=json',
+          rsp.visitSuccess()
+        )
         store
           .dispatch(visit('/first?props_at=foo&format=json'))
           .then((meta) => {
@@ -1307,7 +1370,7 @@ describe('action creators', () => {
 
         const store = buildStore(initialState)
 
-        fetchMock.mock('/redirecting_url?format=json', {
+        fetchMock.mock('https://example.com/redirecting_url?format=json', {
           status: 200,
           redirectUrl: '/foo',
           headers: {
@@ -1335,7 +1398,10 @@ describe('action creators', () => {
 
         const store = buildStore(initialState)
 
-        fetchMock.mock('/first?format=json', rsp.visitSuccess())
+        fetchMock.mock(
+          'https://example.com/first?format=json',
+          rsp.visitSuccess()
+        )
 
         return store
           .dispatch(visit('/first', { revisit: true }))
@@ -1357,7 +1423,10 @@ describe('action creators', () => {
 
       const store = buildStore(initialState)
 
-      fetchMock.mock('/same_page?format=json', rsp.visitSuccess())
+      fetchMock.mock(
+        'https://example.com/same_page?format=json',
+        rsp.visitSuccess()
+      )
 
       return store.dispatch(visit('/same_page')).then((meta) => {
         expect(meta.redirected).toEqual(false)
@@ -1376,7 +1445,10 @@ describe('action creators', () => {
 
         const store = buildStore(initialState)
 
-        fetchMock.mock('/first?format=json', rsp.visitSuccess())
+        fetchMock.mock(
+          'https://example.com/first?format=json',
+          rsp.visitSuccess()
+        )
         store.dispatch(visit('/first')).catch((err) => {
           expect(err.message).toEqual('The operation was aborted.')
           done()
@@ -1396,7 +1468,10 @@ describe('action creators', () => {
 
         const store = buildStore(initialState)
 
-        fetchMock.mock('/first?format=json', rsp.visitSuccess())
+        fetchMock.mock(
+          'https://example.com/first?format=json',
+          rsp.visitSuccess()
+        )
 
         const expectedFetchUrl = '/first?props_at=foo&format=json'
         store
@@ -1426,7 +1501,10 @@ describe('action creators', () => {
 
         const store = buildStore(initialState)
 
-        fetchMock.mock('/first?props_at=foo&format=json', rsp.visitSuccess())
+        fetchMock.mock(
+          'https://example.com/first?props_at=foo&format=json',
+          rsp.visitSuccess()
+        )
 
         const expectedFetchUrl = '/first?props_at=foo&format=json'
         store
@@ -1459,7 +1537,7 @@ describe('action creators', () => {
 
         let mockResponse = rsp.graftSuccessWithNewZip()
         fetchMock.mock(
-          '/details?props_at=data.address&format=json',
+          'https://example.com/details?props_at=data.address&format=json',
           mockResponse
         )
 
@@ -1511,7 +1589,7 @@ describe('action creators', () => {
 
         let mockResponse = rsp.graftSuccessWithNewZip()
         fetchMock.mock(
-          '/details?props_at=data.address&format=json',
+          'https://example.com/details?props_at=data.address&format=json',
           mockResponse
         )
 
@@ -1569,7 +1647,10 @@ describe('action creators', () => {
 
       let mockResponse = rsp.graftSuccessWithNewZip()
       mockResponse.componentIdentifier = 'DoesNotExist'
-      fetchMock.mock('/details?props_at=data.address&format=json', mockResponse)
+      fetchMock.mock(
+        'https://example.com/details?props_at=data.address&format=json',
+        mockResponse
+      )
 
       expect(() => {
         return store.dispatch(

--- a/superglue/spec/lib/utils/request.spec.js
+++ b/superglue/spec/lib/utils/request.spec.js
@@ -4,7 +4,6 @@ import {
   argsForFetch,
   handleServerErrors,
 } from '../../../lib/utils/request'
-import parse from 'url-parse'
 import Headers from 'fetch-headers'
 
 describe('isValidResponse', () => {
@@ -59,7 +58,7 @@ describe('argsForFetch', () => {
     const args = argsForFetch(getState, '/foo')
 
     expect(args).toEqual([
-      '/foo?format=json',
+      'https://example.com/foo?format=json',
       {
         method: 'GET',
         headers: {
@@ -85,7 +84,7 @@ describe('argsForFetch', () => {
     const args = argsForFetch(getState, '/foo', { signal })
 
     expect(args).toEqual([
-      '/foo?format=json',
+      'https://example.com/foo?format=json',
       {
         method: 'GET',
         headers: {
@@ -109,7 +108,7 @@ describe('argsForFetch', () => {
     const args = argsForFetch(getState, '/foo', { method: 'PUT' })
 
     expect(args).toEqual([
-      '/foo?format=json',
+      'https://example.com/foo?format=json',
       {
         method: 'POST',
         headers: {
@@ -138,7 +137,7 @@ describe('argsForFetch', () => {
     const args = argsForFetch(getState, '/foo')
 
     expect(args).toEqual([
-      '/foo?format=json',
+      'https://example.com/foo?format=json',
       {
         method: 'GET',
         headers: {
@@ -148,7 +147,7 @@ describe('argsForFetch', () => {
         },
         signal: undefined,
         credentials: 'same-origin',
-        referrer: '/some_current_url',
+        referrer: 'https://example.com/some_current_url',
       },
     ])
   })
@@ -163,7 +162,7 @@ describe('argsForFetch', () => {
     const args = argsForFetch(getState, '/foo', { body: 'ignored' })
 
     expect(args).toEqual([
-      '/foo?format=json',
+      'https://example.com/foo?format=json',
       {
         method: 'GET',
         headers: {
@@ -182,7 +181,7 @@ describe('argsForFetch', () => {
     })
 
     expect(args2).toEqual([
-      '/foo?format=json',
+      'https://example.com/foo?format=json',
       {
         method: 'HEAD',
         headers: {

--- a/superglue/spec/lib/utils/url.spec.js
+++ b/superglue/spec/lib/utils/url.spec.js
@@ -6,33 +6,32 @@ import {
   pathQueryHash,
   hasPropsAt,
 } from '../../../lib/utils/url'
-import parse from 'url-parse'
 
 describe('.withoutHash', () => {
-  it('take a url and removes the hash', () => {
-    const url = withoutHash('http://www.github.com#abc')
+  it('take a path and removes the hash', () => {
+    const url = withoutHash('/hello#abc')
 
-    expect(url).toEqual('http://www.github.com/')
+    expect(url).toEqual('/hello')
   })
 
-  it('takes a blank and returns blank', () => {
-    const url = withoutHash('http://www.github.com#abc')
+  it('takes a blank and returns a slash', () => {
+    const url = withoutHash('')
 
-    expect(url).toEqual('http://www.github.com/')
+    expect(url).toEqual('/')
   })
 })
 
 describe('.removePropsAt', () => {
-  it('take a url and removes the props_at param', () => {
-    const url = removePropsAt('http://www.github.com?props_at=hello')
+  it('take a path and removes the props_at param', () => {
+    const url = removePropsAt('/posts?a=1&props_at=hello')
 
-    expect(url).toEqual('http://www.github.com/')
+    expect(url).toEqual('/posts?a=1')
   })
 
   it('take a blank url and returns blank', () => {
     const url = removePropsAt('')
 
-    expect(url).toEqual('')
+    expect(url).toEqual('/')
   })
 })
 
@@ -43,10 +42,10 @@ describe('.pathQuery', () => {
     expect(url).toEqual('/path?props_at=hello')
   })
 
-  it('take a blank url and returns blank', () => {
+  it('take a blank url and returns a slash', () => {
     const url = pathQuery('')
 
-    expect(url).toEqual('')
+    expect(url).toEqual('/')
   })
 })
 
@@ -57,10 +56,10 @@ describe('.pathQueryHash', () => {
     expect(url).toEqual('/?props_at=hello#fooo')
   })
 
-  it('take a blank url and returns blank', () => {
+  it('take a blank url and returns a slash', () => {
     const url = pathQueryHash('')
 
-    expect(url).toEqual('')
+    expect(url).toEqual('/')
   })
 })
 


### PR DESCRIPTION
Fix dedup URL params

The depedency, url-parse, will dedup repeated url params. For example
`?fop=1&foo2` and will keep the first one. This doesn't play nicely with rails
Rack params as dups may indicate a structural array. This change migrates
`url-parse` to the browser's own 'URLSearchParams' and `URL`.

With the change, we had to:
1. Make minimal changes to `url.ts` helpers. You'll notice that we have a FAKE_ORIGIN as a fallback for the
`URL` usage, but in every instances, we have no 't need the origin at all. Either we replace the origin with a blank
or we only a part of the url like pathname.
2. baseUrl is required, but existing testing in isolation has it as optional. The update to the tests now reflect
that requirement

