### PR TITLE
Add support for stream responses

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -1,14 +1,15 @@
-import { urlToPageKey, getIn, propsAtParam } from '../utils'
+import { urlToPageKey, getIn, setIn, propsAtParam } from '../utils'
 import {
   saveResponse,
   GRAFTING_ERROR,
   GRAFTING_SUCCESS,
-  updateFragments,
   handleGraft,
+  saveFragment,
+  handleFragmentGraft,
 } from '../actions'
 import { remote } from './requests'
 import {
-  VisitResponse,
+  SaveResponse,
   SaveAndProcessPageThunk,
   DefermentThunk,
   GraftResponse,
@@ -70,67 +71,44 @@ function fetchDeferments(
  */
 export function saveAndProcessPage(
   pageKey: string,
-  page: VisitResponse | GraftResponse
+  page: SaveResponse | GraftResponse
 ): SaveAndProcessPageThunk {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     pageKey = urlToPageKey(pageKey)
 
-    const { defers = [] } = page
+    let nextPage = page
 
-    if ('action' in page) {
-      const prevPage = getState().pages[pageKey]
-      dispatch(handleGraft({ pageKey, page }))
-      const currentPage = getState().pages[pageKey]
+    page.fragments.reverse().forEach((fragment) => {
+      const { type, path } = fragment
+      const node = getIn(nextPage, path) as JSONMappable
+      nextPage = setIn(page, path, { __id: type })
 
-      currentPage.fragments.forEach((fragment) => {
-        const { type, path } = fragment
-        // A fragment only works on a block in props_template. So using getIn
-        // will always return a JSONMappable
-        const currentFragment = getIn(currentPage, path) as JSONMappable
-        const prevFragment = getIn(prevPage, path) as JSONMappable
-        if (!prevFragment) {
-          dispatch(
-            updateFragments({
-              name: type,
-              pageKey: pageKey,
-              value: currentFragment,
-              path,
-            })
-          )
-        } else if (currentFragment !== prevFragment) {
-          dispatch(
-            updateFragments({
-              name: type,
-              pageKey: pageKey,
-              value: currentFragment,
-              previousValue: prevFragment,
-              path,
-            })
-          )
-        }
-      })
-    } else {
-      dispatch(saveResponse({ pageKey, page }))
-      const currentPage = getState().pages[pageKey]
+      dispatch(
+        saveFragment({
+          fragmentKey: type,
+          data: node,
+        })
+      )
+    })
 
-      currentPage.fragments.forEach((fragment) => {
-        const { type, path } = fragment
-        const currentFragment = getIn(currentPage, path) as JSONMappable
-
+    if (nextPage.action === 'graft') {
+      if (typeof nextPage.fragmentContext === 'string') {
         dispatch(
-          updateFragments({
-            name: type,
-            pageKey: pageKey,
-            value: currentFragment,
-            path,
+          handleFragmentGraft({
+            fragmentKey: nextPage.fragmentContext,
+            response: nextPage,
           })
         )
-      })
+      } else {
+        dispatch(handleGraft({ pageKey, page: nextPage }))
+      }
+    } else {
+      dispatch(saveResponse({ pageKey, page: nextPage }))
     }
 
     const hasFetch = typeof fetch != 'undefined'
     if (hasFetch) {
-      return dispatch(fetchDeferments(pageKey, defers)).then(() =>
+      return dispatch(fetchDeferments(pageKey, nextPage.defers)).then(() =>
         Promise.resolve()
       )
     } else {

--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -9,13 +9,13 @@ import {
 } from '../actions'
 import { remote } from './requests'
 import {
-  SaveResponse,
   SaveAndProcessPageThunk,
   DefermentThunk,
-  GraftResponse,
   Defer,
   JSONMappable,
+  PageResponse,
 } from '../types'
+import { handleStreamResponse } from './stream'
 export * from './requests'
 
 function fetchDeferments(
@@ -71,7 +71,7 @@ function fetchDeferments(
  */
 export function saveAndProcessPage(
   pageKey: string,
-  page: SaveResponse | GraftResponse
+  page: PageResponse
 ): SaveAndProcessPageThunk {
   return (dispatch) => {
     pageKey = urlToPageKey(pageKey)
@@ -102,6 +102,11 @@ export function saveAndProcessPage(
       } else {
         dispatch(handleGraft({ pageKey, page: nextPage }))
       }
+    } else if (nextPage.action === 'stream') {
+      // We resolve the promise here because fragment responses
+      // have deferment disabled.
+      dispatch(handleStreamResponse(nextPage))
+      return Promise.resolve()
     } else {
       dispatch(saveResponse({ pageKey, page: nextPage }))
     }

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -17,7 +17,6 @@ import {
 import { saveAndProcessPage } from './index'
 import {
   FetchArgs,
-  VisitResponse,
   PageResponse,
   Page,
   SuperglueState,
@@ -27,6 +26,7 @@ import {
   VisitCreator,
   NavigationAction,
   VisitMeta,
+  BeforeSave,
 } from '../types'
 
 function handleFetchErr(
@@ -40,7 +40,7 @@ function handleFetchErr(
 
 function buildMeta(
   pageKey: string,
-  page: VisitResponse,
+  page: PageResponse,
   state: SuperglueState,
   rsp: Response,
   fetchArgs: FetchArgs
@@ -66,12 +66,14 @@ export class MismatchedComponentError extends Error {
   }
 }
 
+const defaultBeforeSave: BeforeSave = (prevPage, receivedPage) => receivedPage
+
 export const remote: RemoteCreator = (
   path,
   {
     pageKey: targetPageKey,
     force = false,
-    beforeSave = (prevPage: Page, receivedPage: PageResponse) => receivedPage,
+    beforeSave = defaultBeforeSave,
     ...rest
   } = {}
 ) => {
@@ -233,6 +235,7 @@ function calculateNavAction(
   revisit: boolean
 ) {
   let navigationAction: NavigationAction = 'push'
+
   if (!rsp.redirected && !isGet) {
     navigationAction = 'replace'
   }

--- a/superglue/lib/action_creators/stream.ts
+++ b/superglue/lib/action_creators/stream.ts
@@ -1,0 +1,203 @@
+import { ThunkAction } from 'redux-thunk'
+import { Action } from '@reduxjs/toolkit'
+import { setIn, getIn } from '../utils'
+import { appendToFragment, prependToFragment, saveFragment } from '../actions'
+import { JSONMappable, RootState, StreamResponse } from '../types'
+import { StreamMessage } from '../hooks/useStreamSource'
+
+export type StreamThunk = ThunkAction<void, RootState, undefined, Action>
+export type StreamHandleThunk = ThunkAction<void, RootState, undefined, Action>
+
+export interface StreamThunkOptions {
+  saveAs?: string
+}
+
+/**
+ * Stream thunk equivalent to StreamActions.prepend()
+ * Prepends data to specified fragments, optionally saving as a new fragment
+ */
+export const streamPrepend = (
+  fragments: string[],
+  data: JSONMappable,
+  options: StreamThunkOptions = {}
+): StreamThunk => {
+  return (dispatch) => {
+    if (options.saveAs) {
+      const { saveAs } = options
+      dispatch(
+        saveFragment({
+          fragmentKey: saveAs,
+          data,
+        })
+      )
+
+      fragments.forEach((fragmentKey) => {
+        dispatch(
+          prependToFragment({
+            fragmentKey,
+            data: {
+              __id: saveAs,
+            },
+          })
+        )
+      })
+    } else {
+      fragments.forEach((fragmentKey) => {
+        dispatch(
+          prependToFragment({
+            fragmentKey: fragmentKey,
+            data: data,
+          })
+        )
+      })
+    }
+  }
+}
+
+/**
+ * Stream thunk equivalent to StreamActions.append()
+ * Appends data to specified fragments, optionally saving as a new fragment
+ */
+export const streamAppend = (
+  fragments: string[],
+  data: JSONMappable,
+  options: StreamThunkOptions = {}
+): StreamThunk => {
+  return (dispatch) => {
+    if (options.saveAs) {
+      const { saveAs } = options
+      dispatch(
+        saveFragment({
+          fragmentKey: saveAs,
+          data,
+        })
+      )
+
+      fragments.forEach((fragmentKey) => {
+        dispatch(
+          appendToFragment({
+            fragmentKey,
+            data: {
+              __id: saveAs,
+            },
+          })
+        )
+      })
+    } else {
+      fragments.forEach((fragmentKey) => {
+        dispatch(
+          appendToFragment({
+            fragmentKey,
+            data,
+          })
+        )
+      })
+    }
+  }
+}
+
+/**
+ * Stream thunk equivalent to StreamActions.save()
+ * Saves data to a specific fragment
+ */
+export const streamSave = (
+  fragment: string,
+  data: JSONMappable
+): StreamThunk => {
+  return (dispatch) => {
+    dispatch(
+      saveFragment({
+        fragmentKey: fragment,
+        data,
+      })
+    )
+  }
+}
+
+export const handleStreamMessage = (rawMessage: string): StreamHandleThunk => {
+  return (dispatch) => {
+    const message = JSON.parse(rawMessage) as StreamMessage
+
+    let nextMessage = message
+
+    if (message.action !== 'refresh') {
+      message.fragments.reverse().forEach((fragment) => {
+        const { type, path } = fragment
+        const node = getIn(nextMessage as JSONMappable, path) as JSONMappable
+        nextMessage = setIn(nextMessage, path, { __id: type })
+
+        dispatch(
+          saveFragment({
+            fragmentKey: type,
+            data: node,
+          })
+        )
+      })
+    }
+
+    if (nextMessage.type === 'message') {
+      if (nextMessage.action === 'append') {
+        dispatch(
+          streamAppend(
+            nextMessage.fragmentKeys,
+            nextMessage.data,
+            nextMessage.options
+          )
+        )
+      }
+
+      if (nextMessage.action === 'prepend') {
+        dispatch(
+          streamPrepend(
+            nextMessage.fragmentKeys,
+            nextMessage.data,
+            nextMessage.options
+          )
+        )
+      }
+
+      if (nextMessage.action === 'save') {
+        dispatch(streamSave(nextMessage.fragmentKeys[0], nextMessage.data))
+      }
+    }
+  }
+}
+
+export const handleStreamResponse = (
+  response: StreamResponse
+): StreamHandleThunk => {
+  return (dispatch) => {
+    let nextResponse = response
+
+    nextResponse.fragments.reverse().forEach((fragment) => {
+      const { type, path } = fragment
+      const node = getIn(nextResponse as JSONMappable, path) as JSONMappable
+      nextResponse = setIn(nextResponse, path, { __id: type })
+
+      dispatch(
+        saveFragment({
+          fragmentKey: type,
+          data: node,
+        })
+      )
+    })
+
+    nextResponse.data.forEach((message) => {
+      if (message.action === 'append') {
+        dispatch(
+          streamAppend(message.fragmentKeys, message.data, message.options)
+        )
+      }
+
+      if (message.action === 'prepend') {
+        dispatch(
+          streamPrepend(message.fragmentKeys, message.data, message.options)
+        )
+      }
+
+      if (message.action === 'save') {
+        dispatch(streamSave(message.fragmentKeys[0], message.data))
+      }
+    })
+  }
+}

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -3,9 +3,8 @@ import {
   FetchArgs,
   PageKey,
   GraftResponse,
-  VisitResponse,
+  SaveResponse,
   JSONMappable,
-  Keypath,
 } from './types'
 import { urlToPageKey } from './utils'
 
@@ -14,7 +13,7 @@ export const GRAFTING_SUCCESS = '@@superglue/GRAFTING_SUCCESS'
 
 export const saveResponse = createAction(
   '@@superglue/SAVE_RESPONSE',
-  ({ pageKey, page }: { pageKey: string; page: VisitResponse }) => {
+  ({ pageKey, page }: { pageKey: string; page: SaveResponse }) => {
     pageKey = urlToPageKey(pageKey)
 
     return {
@@ -43,31 +42,6 @@ export const handleGraft = createAction(
 export const superglueError = createAction<{ message: string }>(
   '@@superglue/ERROR'
 )
-
-/**
- * A redux action called whenever a fragment is received from `visit` or updated
- * using `remote`. Its a useful action to use for cross cutting concerns like a
- * shared header or a shopping cart. For example:
- *
- * ```
- * import { updateFragments } from '@thoughtbot/superglue'
- *
- * export const exampleSlice = createSlice({
- *  name: 'Example',
- *  initialState: {},
- *  extraReducers: (builder) => {
- *    builder.addCase(updateFragments, (state, action) => {
- *      // Update the slice using the latest and greatest.
- *      return action.value
- * ```
- */
-export const updateFragments = createAction<{
-  name: string
-  path: Keypath
-  pageKey: PageKey
-  value: JSONMappable
-  previousValue?: JSONMappable
-}>('@@superglue/UPDATE_FRAGMENTS')
 
 /**
  * A redux action you can dispatch to copy a page from one pageKey to another. Its
@@ -167,3 +141,57 @@ export const historyChange = createAction<{
 export const setActivePage = createAction<{
   pageKey: PageKey
 }>('@@superglue/SET_ACTIVE_PAGE')
+
+export const handleFragmentGraft = createAction(
+  '@@superglue/HANDLE_FRAGMENT_GRAFT',
+  ({
+    fragmentKey,
+    response,
+  }: {
+    fragmentKey: string
+    response: GraftResponse
+  }) => {
+    return {
+      payload: {
+        response,
+        fragmentKey,
+      },
+    }
+  }
+)
+
+export const saveFragment = createAction(
+  '@@superglue/SAVE_FRAGMENT',
+  ({ fragmentKey, data }: { fragmentKey: string; data: JSONMappable }) => {
+    return {
+      payload: {
+        fragmentKey,
+        data,
+      },
+    }
+  }
+)
+
+export const appendToFragment = createAction(
+  '@@superglue/APPEND_TO_FRAGMENT',
+  ({ data, fragmentKey }: { data: JSONMappable; fragmentKey: string }) => {
+    return {
+      payload: {
+        data,
+        fragmentKey,
+      },
+    }
+  }
+)
+
+export const prependToFragment = createAction(
+  '@@superglue/PREPEND_TO_FRAGMENT',
+  ({ data, fragmentKey }: { data: JSONMappable; fragmentKey: string }) => {
+    return {
+      payload: {
+        data,
+        fragmentKey: fragmentKey,
+      },
+    }
+  }
+)

--- a/superglue/lib/hooks/index.ts
+++ b/superglue/lib/hooks/index.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import { JSONMappable, Page, RootState, SuperglueState } from '../types'
+export { useFragment } from './useFragment'
 
 /**
  * A lightweight hook that grabs the superglue state from the store.

--- a/superglue/lib/hooks/useFragment.tsx
+++ b/superglue/lib/hooks/useFragment.tsx
@@ -1,0 +1,50 @@
+import { useDispatch, useSelector } from 'react-redux'
+import { produce, Draft } from 'immer'
+import { JSONMappable, RootState } from '../types'
+import { saveFragment } from '../actions'
+
+type FragmentRef = string | { __id: string }
+
+type FragmentUpdater<T> = (draft: Draft<T>) => void | Draft<T>
+
+type FragmentSetter<T> = {
+  (updater: FragmentUpdater<T>): void
+}
+
+/**
+ * A lightweight hook that grabs a fragment from Redux store
+ * Returns a tuple similar to useState: [fragment, setFragment]
+ */
+export function useFragment<T = unknown>(
+  fragmentRef: FragmentRef
+): [T | undefined, FragmentSetter<T>] {
+  const fragmentKey =
+    typeof fragmentRef === 'string' ? fragmentRef : fragmentRef.__id
+
+  const dispatch = useDispatch()
+
+  const fragment = useSelector<RootState, T | undefined>(
+    (state) => state.fragments[fragmentKey] as T
+  )
+
+  const setFragment: FragmentSetter<T> = (updater: FragmentUpdater<T>) => {
+    const currentFragment = fragment
+    if (currentFragment === undefined) {
+      console.warn(
+        `Fragment '${fragmentKey}' is undefined. Cannot apply update.`
+      )
+      return
+    }
+
+    const updatedFragment = produce(currentFragment, updater)
+
+    dispatch(
+      saveFragment({
+        fragmentKey,
+        data: updatedFragment as JSONMappable,
+      })
+    )
+  }
+
+  return [fragment, setFragment]
+}

--- a/superglue/lib/hooks/useStreamSource.tsx
+++ b/superglue/lib/hooks/useStreamSource.tsx
@@ -1,0 +1,231 @@
+import {
+  ChannelNameWithParams,
+  Consumer,
+  Subscription,
+} from '@rails/actioncable'
+import { setIn, getIn } from '../utils'
+import { useState, useEffect, useRef, createContext, useContext } from 'react'
+import { appendToFragment, prependToFragment, saveFragment } from '../actions'
+import { ApplicationRemote, Fragment } from '../types'
+import { useSuperglue } from '.'
+import { debounce, DebouncedFunc } from 'lodash'
+import { lastRequestIds } from '../utils'
+
+type StreamSourceProps = string | ChannelNameWithParams
+
+type StreamMessage =
+  | {
+      type: 'message'
+      data: JSONMappable
+      fragmentKeys: string[]
+      action: 'append' | 'prepend' | 'save'
+      options: Record<string, string>
+      fragments: Fragment[]
+    }
+  | {
+      type: 'message'
+      action: 'refresh'
+      requestId: string
+      options: Record<string, string>
+    }
+
+import { SuperglueStore, JSONMappable } from '../types'
+
+export class StreamActions {
+  public attributePrefix: string
+  public remote: DebouncedFunc<ApplicationRemote>
+  private store: SuperglueStore
+
+  constructor({
+    remote,
+    store,
+  }: {
+    remote: ApplicationRemote
+    store: SuperglueStore
+  }) {
+    this.store = store
+    this.remote = debounce(remote, 300)
+  }
+
+  refresh(pageKey: string) {
+    this.remote(pageKey)
+  }
+
+  prepend(
+    fragments: string[],
+    data: JSONMappable,
+    options: { saveAs?: string } = {}
+  ) {
+    if (options.saveAs) {
+      const { saveAs } = options
+      this.store.dispatch(
+        saveFragment({
+          fragmentKey: saveAs,
+          data,
+        })
+      )
+
+      fragments.forEach((fragmentKey) => {
+        this.store.dispatch(
+          prependToFragment({
+            fragmentKey,
+            data: {
+              __id: saveAs,
+            },
+          })
+        )
+      })
+    } else {
+      fragments.forEach((fragmentKey) => {
+        this.store.dispatch(
+          prependToFragment({
+            fragmentKey: fragmentKey,
+            data: data,
+          })
+        )
+      })
+    }
+  }
+
+  save(fragment: string, data: JSONMappable) {
+    this.store.dispatch(
+      saveFragment({
+        fragmentKey: fragment,
+        data,
+      })
+    )
+  }
+
+  append(
+    fragments: string[],
+    data: JSONMappable,
+    options: { saveAs?: string } = {}
+  ) {
+    if (options.saveAs) {
+      const { saveAs } = options
+      this.store.dispatch(
+        saveFragment({
+          fragmentKey: saveAs,
+          data,
+        })
+      )
+
+      fragments.forEach((fragmentKey) => {
+        this.store.dispatch(
+          appendToFragment({
+            fragmentKey,
+            data: {
+              __id: saveAs,
+            },
+          })
+        )
+      })
+    } else {
+      fragments.forEach((fragmentKey) => {
+        this.store.dispatch(
+          appendToFragment({
+            fragmentKey,
+            data,
+          })
+        )
+      })
+    }
+  }
+
+  handle(rawMessage: string, currentPageKey: string) {
+    const message = JSON.parse(rawMessage) as StreamMessage
+    const { superglue } = this.store.getState()
+    const nextPageKey = superglue.currentPageKey
+
+    let nextMessage = message
+
+    if (message.action !== 'refresh') {
+      message.fragments.reverse().forEach((fragment) => {
+        const { type, path } = fragment
+        const node = getIn(nextMessage as JSONMappable, path) as JSONMappable
+        nextMessage = setIn(nextMessage, path, { __id: type })
+
+        this.store.dispatch(
+          saveFragment({
+            fragmentKey: type,
+            data: node,
+          })
+        )
+      })
+    }
+
+    if (nextMessage.type === 'message') {
+      if (nextMessage.action === 'append') {
+        this.append(
+          nextMessage.fragmentKeys,
+          nextMessage.data,
+          nextMessage.options
+        )
+      }
+
+      if (nextMessage.action === 'prepend') {
+        this.prepend(
+          nextMessage.fragmentKeys,
+          nextMessage.data,
+          nextMessage.options
+        )
+      }
+
+      if (nextMessage.action === 'save') {
+        // replace should not be targets... but target
+        this.save(nextMessage.fragmentKeys[0], nextMessage.data)
+      }
+
+      if (
+        message.action === 'refresh' &&
+        currentPageKey === nextPageKey &&
+        !lastRequestIds.has(message.requestId)
+      ) {
+        this.refresh(currentPageKey)
+      }
+    }
+  }
+}
+
+export const CableContext = createContext<{
+  cable: Consumer | null
+  streamActions: StreamActions | null
+}>({
+  cable: null,
+  streamActions: null,
+})
+
+export default function useStreamSource(channel: StreamSourceProps) {
+  const { cable, streamActions } = useContext(CableContext)
+  const [connected, setConnected] = useState(false)
+  const { currentPageKey } = useSuperglue()
+  const subscriptionRef = useRef<Subscription | null>(null)
+
+  useEffect(() => {
+    if (cable) {
+      const subscription = cable.subscriptions.create(channel, {
+        received: (message) => {
+          streamActions?.handle(message, currentPageKey)
+        },
+        connected: () => {
+          setConnected(true)
+        },
+        disconnected: () => setConnected(false),
+      })
+
+      subscriptionRef.current = subscription
+
+      return () => subscription.unsubscribe()
+    } else {
+      subscriptionRef.current = null
+      setConnected(false)
+
+      return () => {}
+    }
+  }, [cable, channel, currentPageKey])
+
+  return {
+    connected,
+    subscription: subscriptionRef.current,
+  }
+}

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -5,6 +5,9 @@ import { saveAndProcessPage } from './action_creators'
 import { historyChange, setCSRFToken } from './actions'
 import { Provider } from 'react-redux'
 
+import { CableContext, StreamActions } from './hooks/useStreamSource'
+import { createConsumer } from '@rails/actioncable'
+
 import { createBrowserHistory, createMemoryHistory } from 'history'
 
 import { NavigationProvider } from './components/Navigation'
@@ -14,7 +17,6 @@ export {
   beforeFetch,
   beforeVisit,
   beforeRemote,
-  updateFragments,
   copyPage,
   removePage,
   saveResponse,
@@ -24,7 +26,7 @@ export {
 export * from './types'
 
 import {
-  VisitResponse,
+  SaveResponse,
   ApplicationProps,
   NavigateTo,
   SuperglueStore,
@@ -34,6 +36,10 @@ export { superglueReducer, pageReducer, rootReducer } from './reducers'
 export { getIn } from './utils/immutability'
 export { urlToPageKey }
 export * from './hooks'
+import useStreamSource from './hooks/useStreamSource'
+export { useStreamSource }
+
+const cable = createConsumer()
 
 const hasWindow = typeof window !== 'undefined'
 
@@ -49,7 +55,7 @@ const createHistory = () => {
 
 export const prepareStore = (
   store: SuperglueStore,
-  initialPage: VisitResponse,
+  initialPage: SaveResponse,
   path: string
 ) => {
   const initialPageKey = urlToPageKey(path)
@@ -93,12 +99,15 @@ export const setup = ({
     store,
   })
 
+  const streamActions = new StreamActions({ remote, store })
+
   return {
     visit,
     remote,
     nextHistory,
     initialPageKey,
     ujs: handlers,
+    streamActions,
   }
 }
 
@@ -121,31 +130,34 @@ function Application({
 }: ApplicationProps) {
   const navigatorRef = useRef<{ navigateTo: NavigateTo } | null>(null)
 
-  const { visit, remote, nextHistory, initialPageKey, ujs } = useMemo(() => {
-    return setup({
-      initialPage,
-      baseUrl,
-      path,
-      store,
-      buildVisitAndRemote,
-      history,
-      navigatorRef,
-    })
-  }, [])
+  const { visit, remote, nextHistory, initialPageKey, ujs, streamActions } =
+    useMemo(() => {
+      return setup({
+        initialPage,
+        baseUrl,
+        path,
+        store,
+        buildVisitAndRemote,
+        history,
+        navigatorRef,
+      })
+    }, [])
 
   // The Nav component is pretty bare and can be inherited from for custom
   // behavior or replaced with your own.
   return (
     <div onClick={ujs.onClick} onSubmit={ujs.onSubmit} {...rest}>
       <Provider store={store}>
-        <NavigationProvider
-          ref={navigatorRef}
-          visit={visit}
-          remote={remote}
-          mapping={mapping}
-          history={nextHistory}
-          initialPageKey={initialPageKey}
-        />
+        <CableContext.Provider value={{ streamActions, cable }}>
+          <NavigationProvider
+            ref={navigatorRef}
+            visit={visit}
+            remote={remote}
+            mapping={mapping}
+            history={nextHistory}
+            initialPageKey={initialPageKey}
+          />
+        </CableContext.Provider>
       </Provider>
     </div>
   )

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -142,12 +142,12 @@ export type Defer = {
 }
 
 /**
- * The VisitResponse is a protocol, a shape that is responsible for full page
+ * The SaveResponse is a protocol, a shape that is responsible for full page
  * visits in Superglue. Its meant to be implemented by the server and if you are
  * using superglue_rails, the generators would have generated a props_template
  * layout and view that would shape the visit responses for you.
  */
-export type VisitResponse<T = JSONMappable> = {
+export type SaveResponse<T = JSONMappable> = {
   data: T
   componentIdentifier: ComponentIdentifier
   assets: string[]
@@ -155,15 +155,16 @@ export type VisitResponse<T = JSONMappable> = {
   fragments: Fragment[]
   defers: Defer[]
   slices: JSONObject
+  action: 'savePage'
 
   renderedAt: number
   restoreStrategy: RestoreStrategy
 }
 
 /**
- * A Page is a VisitResponse that's been saved to the store
+ * A Page is a SaveResponse that's been saved to the store
  */
-export type Page<T = JSONMappable> = VisitResponse<T> & {
+export type Page<T = JSONMappable> = SaveResponse<T> & {
   savedAt: number
 }
 
@@ -178,17 +179,28 @@ export type Page<T = JSONMappable> = VisitResponse<T> & {
  * @property equals to `graft` to indicate a {@link GraftResponse}
  * @interface
  */
-export type GraftResponse<T = JSONMappable> = VisitResponse<T> & {
+export type GraftResponse<T = JSONMappable> = {
+  data: T
+  componentIdentifier: ComponentIdentifier
+  assets: string[]
+  csrfToken?: string
+  fragments: Fragment[]
+  defers: Defer[]
+  slices: JSONObject
   action: 'graft'
+  renderedAt: number
+  restoreStrategy: RestoreStrategy
+
   path: Keypath
+  fragmentContext?: string
 }
 
 /**
- * A PageResponse can be either a {@link GraftResponse} or a {@link VisitResponse}.
+ * A PageResponse can be either a {@link GraftResponse} or a {@link SaveResponse}.
  * Its meant to be implemented by the server and if you are using
  * superglue_rails, the generators will handle both cases.
  */
-export type PageResponse = GraftResponse | VisitResponse
+export type PageResponse = GraftResponse | SaveResponse
 
 /**
  * A Fragment identifies a cross cutting concern, like a shared header or footer.
@@ -207,6 +219,12 @@ export type Fragment = {
  * to mutate the Pages in this store.
  */
 export type AllPages<T = JSONMappable> = Record<PageKey, Page<T>>
+
+/**
+ * The store where all page responses are stored indexed by PageKey. You are encouraged
+ * to mutate the Pages in this store.
+ */
+export type AllFragments = Record<string, JSONMappable>
 
 /**
  * A read only state that contains meta information about
@@ -232,6 +250,7 @@ export interface RootState<T = JSONMappable> {
   superglue: SuperglueState
   /** Every {@link PageResponse} that superglue recieves is stored here.*/
   pages: AllPages<T>
+  fragments: AllFragments
   [name: string]: unknown
 }
 
@@ -243,11 +262,11 @@ export interface RootState<T = JSONMappable> {
 export interface Meta {
   /**
    * The URL of the response converted to a pageKey. Superglue uses this to
-   * persist the {@link VisitResponse} to store, when that happens.
+   * persist the {@link SaveResponse} to store, when that happens.
    */
   pageKey: PageKey
-  /** The {@link VisitResponse} of the page */
-  page: VisitResponse
+  /** The {@link SaveResponse} of the page */
+  page: PageResponse
   /** Indicates if response was redirected */
   redirected: boolean
   /** The original response object*/
@@ -474,7 +493,7 @@ export interface SetupProps {
    * The global var SUPERGLUE_INITIAL_PAGE_STATE is set by your erb
    * template, e.g., application/superglue.html.erb
    */
-  initialPage: VisitResponse
+  initialPage: SaveResponse
   /**
    * The base url prefixed to all calls made by `visit` and
    * `remote`.
@@ -519,7 +538,7 @@ export interface ApplicationProps
    * The global var SUPERGLUE_INITIAL_PAGE_STATE is set by your erb
    * template, e.g., application/superglue.html.erb
    */
-  initialPage: VisitResponse
+  initialPage: SaveResponse
   /**
    * The base url prefixed to all calls made by `visit` and
    * `remote`.

--- a/superglue/lib/types/requests.ts
+++ b/superglue/lib/types/requests.ts
@@ -1,4 +1,4 @@
-import { Meta, VisitMeta, PageKey, VisitResponse } from '.'
+import { Meta, VisitMeta, PageKey, PageResponse, SaveResponse } from '.'
 
 export interface Visit {
   /**
@@ -116,7 +116,8 @@ export interface BeforeSave {
    * remote("/posts", {beforeSave})
    *```
    */
-  (prevPage: VisitResponse, receivedPage: VisitResponse): VisitResponse
+
+  <T extends PageResponse>(prevPage: SaveResponse, receivedPage: T): T
 }
 
 export interface ApplicationRemote {
@@ -133,7 +134,7 @@ export interface ApplicationRemote {
    */
   (
     input: string | PageKey,
-    options: RemoteProps & {
+    options?: RemoteProps & {
       dataset?: {
         [name: string]: string | undefined
       }
@@ -155,7 +156,7 @@ export interface ApplicationVisit {
    */
   (
     input: string | PageKey,
-    options: VisitProps & {
+    options?: VisitProps & {
       dataset?: {
         [name: string]: string | undefined
       }

--- a/superglue/lib/utils/helpers.ts
+++ b/superglue/lib/utils/helpers.ts
@@ -1,7 +1,7 @@
-import { GraftResponse, HistoryState, VisitResponse } from '../types'
+import { GraftResponse, HistoryState, SaveResponse } from '../types'
 import { urlToPageKey } from './url'
 
-export function isGraft(page: GraftResponse | VisitResponse): boolean {
+export function isGraft(page: GraftResponse | SaveResponse): boolean {
   return 'action' in page && page.action === 'graft'
 }
 

--- a/superglue/lib/utils/limited_set.ts
+++ b/superglue/lib/utils/limited_set.ts
@@ -1,0 +1,19 @@
+export class LimitedSet extends Set {
+  private maxSize: number
+
+  constructor(maxSize: number) {
+    super()
+    this.maxSize = maxSize
+  }
+
+  add(value: any) {
+    if (this.size >= this.maxSize) {
+      const iterator = this.values()
+      const oldestValue = iterator.next().value
+      this.delete(oldestValue)
+    }
+    super.add(value)
+
+    return this
+  }
+}

--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -1,6 +1,10 @@
 import { formatForXHR } from './url'
 import { config } from '../config'
 import { BasicRequestInit, ParsedResponse, RootState } from '../types'
+import { LimitedSet } from './limited_set'
+import { v4 as uuidv4 } from 'uuid'
+
+export const lastRequestIds = new LimitedSet(20)
 
 export function isValidResponse(xhr: Response): boolean {
   return isValidContent(xhr) && !downloadingFile(xhr)
@@ -77,6 +81,10 @@ export function argsForFetch(
   nextHeaders['x-requested-with'] = 'XMLHttpRequest'
   nextHeaders['accept'] = 'application/json'
   nextHeaders['x-superglue-request'] = 'true'
+
+  const requestId = uuidv4()
+  lastRequestIds.add(requestId)
+  nextHeaders['X-Superglue-Request-Id'] = requestId
 
   if (method != 'GET' && method != 'HEAD') {
     nextHeaders['content-type'] = 'application/json'

--- a/superglue/package.json
+++ b/superglue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thoughtbot/superglue",
-  "version": "1.0.2",
+  "version": "2.0.0-alpha.1",
   "description": "Use a vanilla Rails with React and Redux",
   "scripts": {
     "build": "tsup",
@@ -66,8 +66,7 @@
     "prettier-eslint": "^16.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-redux": "^7.2.9",
-    "redux": "^5.0.1",
+    "react-redux": "^9.1.2",
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^3.1.0",
     "tsup": "^8.1.0",
@@ -83,6 +82,13 @@
     "react-redux": "^9 || ^8"
   },
   "dependencies": {
-    "history": "^5.3.0"
+    "immer": "^10.0.3",
+    "@rails/actioncable": "^8.0.200",
+    "@types/lodash.debounce": "^4.0.9",
+    "@types/rails__actioncable": "^6.1.11",
+    "history": "^5.3.0",
+    "lodash.debounce": "^4.0.8",
+    "mock-socket": "^2.0.0",
+    "uuid": "^11.1.0"
   }
 }

--- a/superglue/spec/features/navigation.spec.jsx
+++ b/superglue/spec/features/navigation.spec.jsx
@@ -89,6 +89,7 @@ describe('start', () => {
     )
 
     expect(store.getState()).toEqual({
+      fragments: {},
       superglue: {
         currentPageKey: '/home?some=123',
         search: { some: '123' },

--- a/superglue/spec/helpers/polyfill.js
+++ b/superglue/spec/helpers/polyfill.js
@@ -1,16 +1,26 @@
 import { AbortController } from 'abortcontroller-polyfill/dist/cjs-ponyfill'
 import { JSDOM } from 'jsdom'
+import { WebSocket as MockWebSocket} from 'mock-socket'
 
 function setUpDomEnvironment() {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', {
     url: 'http://localhost/',
   })
   const { window } = dom
+  window.WebSocket = MockWebSocket
+  global.WebSocket = MockWebSocket
+
+  /// JSON doesn't include event listeners???
+  // fix this
+  global.addEventListener = () => {}
+  global.removeEventListener = () => {}
 
   global.window = window
   global.document = window.document
-  global.navigator = {
-    userAgent: 'node.js',
+  if (!global.navigator) {
+    global.navigator = {
+      userAgent: 'node.js',
+    }
   }
   copyProps(window, global)
 }

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -60,16 +60,27 @@ const successfulBody = () => {
   })
 }
 
-const successfulFragmentBody = () => {
+const successfulStreamResponseBody = () => {
   return JSON.stringify({
-    data: { heading: 'Some heading 2' },
+    data: [{ 
+      type: 'message',
+      data: {
+        heading: {
+          title: 'hello', 
+          comment: {rating: 'great!'}
+        }
+      },
+      fragmentKeys: ['top'],
+      action: 'save',
+      options: {}
+    }],
     csrfToken: 'token',
     assets: [],
     fragments: [{
-      type: 'heading',
-      path: 'data.heading'
+      type: 'comment',
+      path: 'data.0.data.heading.comment'
     }],
-    action: 'handleFagments'
+    action: 'stream'
   })
 }
 
@@ -1488,6 +1499,32 @@ describe('action creators', () => {
           })
         )
       }).rejects.toThrow(MismatchedComponentError)
+    })
+
+    it('sets the navigation action on meta to none for fragment responses', () => {
+      const store = buildStore({
+        superglue: {
+          currentPageKey: '/current_url',
+          csrfToken: 'token',
+        },
+      })
+
+      fetchMock.mock('https://example.com/foobar?format=json', {
+        body: successfulStreamResponseBody(),
+        headers: {
+          'content-type': 'application/json',
+        },
+      })
+
+      return store
+        .dispatch(visit('/foobar'))
+        .then((meta) => {
+          expect(meta).toEqual(
+            expect.objectContaining({
+              navigationAction: 'none',
+            })
+          )
+        })
     })
   })
 })

--- a/superglue/spec/lib/cable_hook.spec.jsx
+++ b/superglue/spec/lib/cable_hook.spec.jsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import { Server as MockServer } from 'mock-socket'
+import { renderHook, act } from '@testing-library/react'
+import useStreamSource, { CableContext } from '../../lib/hooks/useStreamSource'
+import { describe, it, assert, expect, vi } from 'vitest'
+import * as ActionCable from '@rails/actioncable'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+
+export const testURL = 'ws://cable.example.com/'
+
+export function defer(callback) {
+  if(callback) {
+    setTimeout(callback, 5)
+  }
+}
+
+const consumerTest = function (name, options, callback) {
+  if (options == null) options = {}
+  if (callback == null) {
+    callback = options
+    options = {}
+  }
+
+  if (options.url == null) options.url = testURL
+
+  return it(name, () => {
+    return new Promise((doneAsync) => {
+      const server = new MockServer(options.url, {mock: false})
+      const consumer = ActionCable.createConsumer(options.url)
+      const connection = consumer.connection
+      const monitor = connection.monitor
+
+      if ('subprotocols' in options)
+        consumer.addSubProtocol(options.subprotocols)
+
+      server.on('connection', function () {
+        const clients = server.clients()
+        assert.equal(clients.length, 1)
+        assert.equal(clients[0].readyState, WebSocket.OPEN)
+      })
+
+      server.broadcastTo = function (subscription, data, callback) {
+        if (data == null) { data = {} }
+        data.identifier = subscription.identifier
+
+        if (data.message_type) {
+          data.type = ActionCable.INTERNAL.message_types[data.message_type]
+          delete data.message_type
+        }
+
+        server.send(JSON.stringify(data))
+        defer(callback)
+      }
+
+      const done = function () {
+        consumer.disconnect()
+        server.close()
+        doneAsync()
+      }
+
+      const testData = {
+        assert,
+        consumer,
+        connection,
+        monitor,
+        server,
+        done,
+      }
+
+      if (options.connect === false) {
+        callback(testData)
+      } else {
+        server.on('connection', function () {
+          testData.client = server.clients()[0]
+          callback(testData)
+        })
+        consumer.connect()
+      }
+    })
+  })
+}
+
+describe('hooks', () => {
+  describe('useStreamSource', () => {
+    consumerTest('connects well', async ({ server, consumer, done }) => {
+      const streamActions = {
+        handle: vi.fn(),
+      }
+
+      const preloadedState = {
+        superglue: {
+          currentPageKey: '/current?abc=123',
+          pathname: '/current',
+          search: '?abc=123',
+          csrfToken: 'csrf123',
+          assets: ['js-asset-123'],
+        },
+      }
+      let store = configureStore({
+        preloadedState,
+        reducer: (state) => state,
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>
+          <CableContext.Provider value={{ cable: consumer, streamActions }}>
+            {children}
+          </CableContext.Provider>
+        </Provider>
+      )
+
+      const { result, rerender } = renderHook(
+        () =>
+          useStreamSource({
+            channel: 'TestChannel',
+            signed_stream_name: 'abc',
+          }),
+        { wrapper }
+      )
+
+      rerender()
+
+      expect(result.current.subscription).not.equal(null)
+      expect(result.current.connected).toBe(false)
+      act(() => {
+        server.broadcastTo(result.current.subscription, {message_type: "confirmation"})
+      })
+
+      expect(result.current.connected).toBe(true)
+
+      const spy = vi.spyOn(streamActions, 'handle')
+
+      const message = JSON.stringify({
+        type: 'message',
+        action: 'append',
+        data: { id: 1, name: 'foo' },
+        targets: ['stream_1'],
+        options: {},
+      })
+
+      server.broadcastTo(result.current.subscription, {message})
+
+      await new Promise((r) => setTimeout(r, 5))
+
+      expect(spy).toHaveBeenCalledWith(message, preloadedState.superglue.currentPageKey)
+
+      act(() => {
+        consumer.disconnect()
+      })
+      expect(result.current.connected).toBe(false)
+      done()
+    })
+  })
+})

--- a/superglue/spec/lib/fragment_hook.spec.jsx
+++ b/superglue/spec/lib/fragment_hook.spec.jsx
@@ -1,0 +1,208 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { useFragment } from '../../lib'
+import { describe, it, expect, vi } from 'vitest'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { fragmentReducer } from '../../lib/reducers'
+
+describe('hooks', () => {
+  describe('useFragment', () => {
+    it('returns fragment data and setter function', () => {
+      const preloadedState = {
+        fragments: {
+          'post-1': {
+            title: 'My First Blog Post',
+          }
+        }
+      }
+
+      const store = configureStore({
+        preloadedState,
+        reducer: {fragments: fragmentReducer},
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>{children}</Provider>
+      )
+
+      const { result } = renderHook(() => useFragment('post-1'), { wrapper })
+
+      expect(result.current[0]).toEqual({
+        title: 'My First Blog Post'
+      })
+      expect(typeof result.current[1]).toBe('function')
+    })
+
+    it('returns undefined for non-existent fragment', () => {
+      const preloadedState = {
+        fragments: {}
+      }
+
+      const store = configureStore({
+        preloadedState,
+        reducer: {fragments: fragmentReducer},
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>{children}</Provider>
+      )
+
+      const { result } = renderHook(() => useFragment('user-profile-999'), { wrapper })
+
+      expect(result.current[0]).toBeUndefined()
+      expect(typeof result.current[1]).toBe('function')
+    })
+
+    it('accepts object reference with __id property', () => {
+      const preloadedState = {
+        fragments: {
+          'post-1': {
+            title: 'This is a great article!',
+          }
+        }
+      }
+
+      const store = configureStore({
+        preloadedState,
+        reducer: {fragments: fragmentReducer},
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>{children}</Provider>
+      )
+
+      const fragmentRef = { __id: 'post-1' }
+      const { result } = renderHook(() => useFragment(fragmentRef), { wrapper })
+      expect(result.current[0]).toEqual({
+        title: 'This is a great article!',
+      })
+    })
+
+    it('updates fragment using draft mutation', () => {
+      const preloadedState = {
+        fragments: {
+          'shopping-cart': {
+            items: [
+              { id: 1, name: 'Laptop', price: 10 },
+            ],
+            discounts: {
+              total: 10
+            }
+          }
+        }
+      }
+
+      const store = configureStore({
+        preloadedState,
+        reducer: {fragments: fragmentReducer},
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>{children}</Provider>
+      )
+
+      const { result } = renderHook(() => useFragment('shopping-cart'), { wrapper })
+
+      act(() => {
+        const [, setFragment] = result.current
+        setFragment((draft) => {
+          draft.items.push({ id: 2, name: 'Keyboard', price: 5 })
+        })
+      })
+
+      const cart = store.getState().fragments['shopping-cart']
+      expect(cart).toEqual({
+        items: [
+          { id: 1, name: 'Laptop', price: 10},
+          { id: 2, name: 'Keyboard', price: 5}
+        ],
+        discounts: {
+          total: 10
+        }
+      })
+      expect(cart.discounts).toBe(preloadedState.fragments['shopping-cart'].discounts)
+    })
+
+    it('updates fragment by returning new draft', () => {
+      const preloadedState = {
+        fragments: {
+          'user': {
+            name: 'John Smith',
+            language: 'en',
+            address: {
+              zip: "11222"
+            }
+          }
+        }
+      }
+
+      const store = configureStore({
+        preloadedState,
+        reducer: {fragments: fragmentReducer},
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>{children}</Provider>
+      )
+
+      const { result } = renderHook(() => useFragment('user'), { wrapper })
+
+      act(() => {
+        const [, setFragment] = result.current
+        setFragment(() => {
+          return { 
+            name: 'Jimmy Smith', 
+            language: 'es', 
+            address: {
+              zip: "11222"
+            }
+          }
+        })
+      })
+      const user = store.getState().fragments['user']
+
+      expect(user).toEqual({
+        name: 'Jimmy Smith', 
+        language: 'es', 
+        address: {
+          zip: "11222"
+        }
+      })
+
+      expect(user.address).not.toBe(preloadedState.fragments.user.address)
+    })
+
+    it('warns and does not dispatch when fragment is undefined', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      
+      const preloadedState = {
+        fragments: {}
+      }
+
+      const store = configureStore({
+        preloadedState,
+        reducer: {fragments: fragmentReducer},
+      })
+
+      const wrapper = ({ children }) => (
+        <Provider store={store}>{children}</Provider>
+      )
+
+      const { result } = renderHook(() => useFragment('does-not-exist'), { wrapper })
+
+      act(() => {
+        const [, setFragment] = result.current
+        setFragment((draft) => {
+          draft.title = 'New Draft Title'
+          draft.published = false
+        })
+      })
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Fragment 'does-not-exist' is undefined. Cannot apply update."
+      )
+      expect(store.getState().fragments).toEqual({})
+    })
+  })
+})

--- a/superglue/spec/lib/fragment_reducer.spec.js
+++ b/superglue/spec/lib/fragment_reducer.spec.js
@@ -1,0 +1,253 @@
+import { fragmentReducer } from '../../lib/reducers'
+import {
+  saveFragment,
+  appendToFragment,
+  prependToFragment,
+  handleFragmentGraft,
+} from '../../lib/actions'
+
+describe('reducers', () => {
+  describe('fragments reducer', () => {
+    describe('SAVE_FRAGMENT', () => {
+      it('saves a fragment with the given key', () => {
+        const prevState = {}
+        const action = saveFragment({
+          data: { title: 'Welcome Message' },
+          fragmentKey: 'greeting',
+        })
+        
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          greeting: { title: 'Welcome Message' },
+        })
+      })
+
+      it('preserves existing fragments when saving a new one', () => {
+        const prevState = {
+          posts: [{ content: "Hello" }],
+        }
+        const action = saveFragment({
+          data: { title: 'Getting Started' },
+          fragmentKey: 'tutorial',
+        })
+        
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          posts: [{ content: "Hello" }],
+          tutorial: { title: 'Getting Started' },
+        })
+      })
+    })
+
+    describe('SAVE_FRAGMENT replaces existing fragments', () => {
+      it('replaces a fragment with new data', () => {
+        const prevState = {
+          posts: [{ title: 'First Post' }],
+          greeting: { title: 'Welcome' },
+        }
+        const action = saveFragment({
+          fragmentKey: 'posts',
+          data: [{ title: 'Updated Post' }],
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          posts: [{ title: 'Updated Post' }],
+          greeting: { title: 'Welcome' },
+        })
+      })
+
+      it('creates a new fragment if target does not exist', () => {
+        const prevState = {}
+        const action = saveFragment({
+          fragmentKey: 'footer',
+          data: { title: 'Brand New Content' },
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          footer: { title: 'Brand New Content' },
+        })
+      })
+    })
+
+    describe('APPEND_TO_FRAGMENT', () => {
+      it('appends data to an array fragment', () => {
+        const prevState = {
+          posts: [{ title: 'First Post' }],
+        }
+
+        const action = appendToFragment({
+          data: { title: 'Second Post' },
+          fragmentKey: 'posts',
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          posts: [{ title: 'First Post' }, { title: 'Second Post' }],
+        })
+      })
+
+      it('does not modify non-array fragments', () => {
+        const prevState = {
+          greeting: { title: 'Welcome Message' },
+        }
+
+        const action = appendToFragment({
+          data: { title: 'Another Message' },
+          fragmentKey: 'greeting',
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          greeting: { title: 'Welcome Message' },
+        })
+      })
+
+      it('returns original state if target fragment does not exist', () => {
+        const prevState = {
+          posts: [{ title: 'Existing Post' }],
+        }
+
+        const action = appendToFragment({
+          data: { title: 'New Post' },
+          fragmentKey: 'nonexistent',
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toBe(prevState)
+      })
+    })
+
+    describe('PREPEND_TO_FRAGMENT', () => {
+      it('prepends data to an array fragment', () => {
+        const prevState = {
+          posts: [{ title: 'Existing Post' }],
+        }
+
+        const action = prependToFragment({
+          data: { title: 'New First Post' },
+          fragmentKey: 'posts',
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          posts: [{ title: 'New First Post' }, { title: 'Existing Post' }],
+        })
+      })
+
+
+      it('does not modify non-array fragments', () => {
+        const prevState = {
+          greeting: { title: 'Welcome Message' },
+        }
+
+        const action = prependToFragment({
+          data: { title: 'Another Message' },
+          fragmentKey: 'greeting',
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          greeting: { title: 'Welcome Message' },
+        })
+      })
+
+      it('returns original state if target fragment does not exist', () => {
+        const prevState = {
+          posts: [{ title: 'Existing Post' }],
+        }
+
+        const action = prependToFragment({
+          data: { title: 'New Post' },
+          fragmentKey: 'nonexistent',
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toBe(prevState)
+      })
+    })
+
+    describe('HANDLE_FRAGMENT_GRAFT', () => {
+      it('grafts data onto a fragment at the specified path', () => {
+        const prevState = {
+          userProfile: {
+            name: 'John',
+            settings: {
+              title: 'Dark Theme Preferences',
+            },
+          },
+        }
+
+        const action = handleFragmentGraft({
+          fragmentKey: 'userProfile',
+          response: {
+            data: 'Light Theme Preferences',
+            path: 'settings.title',
+          },
+        })
+
+        const nextState = fragmentReducer(prevState, action)
+
+        expect(nextState).toEqual({
+          userProfile: {
+            name: 'John',
+            settings: {
+              title: 'Light Theme Preferences',
+            },
+          },
+        })
+      })
+
+      it('throws an error if fragment key does not exist', () => {
+        const prevState = {
+          posts: [{ id: 1 }],
+        }
+
+        const action = handleFragmentGraft({
+          fragmentKey: 'nonexistent',
+          response: {
+            data: 'Updated Title',
+            path: 'title',
+          },
+        })
+
+        expect(() => fragmentReducer(prevState, action)).toThrow(
+          'Superglue was looking for nonexistent in your fragments, but could not find it.'
+        )
+      })
+    })
+
+    describe('default case', () => {
+      it('returns the current state for unknown actions', () => {
+        const prevState = {
+          posts: [{ title: 'My First Post' }],
+        }
+
+        const unknownAction = { type: 'UNKNOWN_ACTION' }
+
+        const nextState = fragmentReducer(prevState, unknownAction)
+
+        expect(nextState).toBe(prevState)
+      })
+
+      it('returns empty object for undefined state with unknown action', () => {
+        const unknownAction = { type: 'UNKNOWN_ACTION' }
+
+        const nextState = fragmentReducer(undefined, unknownAction)
+
+        expect(nextState).toEqual({})
+      })
+    })
+  })
+})

--- a/superglue/spec/lib/fragments.spec.jsx
+++ b/superglue/spec/lib/fragments.spec.jsx
@@ -1,0 +1,209 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { rootReducer } from '../../lib'
+import fetchMock from 'fetch-mock'
+import { describe, expect, afterEach, it } from 'vitest'
+import {
+  saveAndProcessPage,
+} from '../../lib/action_creators'
+
+const buildStore = (preloadedState) => {
+  let resultsReducer = (state = [], action) => {
+    return state.concat([action])
+  }
+
+  return configureStore({
+    preloadedState,
+    reducer: {
+      ...rootReducer,
+      results: resultsReducer,
+    },
+  })
+}
+
+const initialState = () => {
+  return {
+    superglue: {
+      currentPageKey: '/bar',
+      csrfToken: 'token',
+    },
+    fragments: {},
+  }
+}
+
+fetchMock.mock()
+
+const buildPage = (attrs) => {
+  const body = {
+    data: {
+      foo: 'barb',
+    },
+    csrfToken: 'token',
+    assets: [],
+    fragments: [],
+    ...attrs,
+  }
+  return body
+}
+
+describe('fragments', () => {
+  describe('saveResponse', () => {
+    afterEach(() => {
+      fetchMock.reset()
+      fetchMock.restore()
+    })
+
+    it('denormalizes fragments on a page and stores them under the fragments slice', async () => {
+      const page = buildPage({
+        data: {
+          header: {
+            avatar: {
+              name: 'John Smith',
+            },
+          },
+        },
+        fragments: [
+          { type: 'header', path: 'data.header' },
+          { type: 'user', path: 'data.header.avatar' },
+        ],
+      })
+      const store = buildStore(initialState())
+
+      await store.dispatch(saveAndProcessPage('/foo', page))
+      const state = store.getState()
+
+      expect(state.pages['/foo']).toEqual(
+        expect.objectContaining({
+          data: {
+            header: {
+              __id: 'header',
+            },
+          },
+        })
+      )
+
+      expect(state.fragments).toEqual({
+        user: {
+          name: 'John Smith',
+        },
+        header: {
+          avatar: { __id: 'user' },
+        },
+      })
+    })
+
+    describe('grafting', () => {
+      it('grafts based on the fragment context the data is in.', async () => {
+        const page = buildPage({
+          action: 'graft',
+          fragments: [],
+          data: {
+            name: 'John Smith',
+          },
+          fragmentContext: 'header',
+          path: 'avatar',
+        })
+
+        const store = buildStore({
+          ...initialState(),
+          pages: {
+            '/foo': buildPage({
+              data: {
+                header: {
+                  __id: 'header',
+                },
+              },
+              fragments: [{ type: 'header', path: 'data.header' }],
+            }),
+          },
+          fragments: {
+            header: {
+              avatar: { name: 'loading....' },
+            },
+          },
+        })
+
+        await store.dispatch(saveAndProcessPage('/foo', page))
+        const state = store.getState()
+
+        expect(state.pages['/foo']).toEqual(
+          expect.objectContaining({
+            data: {
+              header: {
+                __id: 'header',
+              },
+            },
+          })
+        )
+
+        expect(state.fragments).toEqual({
+          header: {
+            avatar: { name: 'John Smith' },
+          },
+        })
+      })
+
+      it('denormalizes new fragments found in the received graft response', async () => {
+        const page = buildPage({
+          action: 'graft',
+          fragments: [{ type: 'personDetails', path: 'data.contactDetails' }],
+          data: {
+            name: 'John Smith',
+            contactDetails: {
+              address: {
+                zip: 10001,
+              },
+            },
+          },
+          fragmentContext: 'header',
+          path: 'avatar',
+        })
+
+        const store = buildStore({
+          ...initialState(),
+          pages: {
+            '/foo': buildPage({
+              data: {
+                header: {
+                  __id: 'header',
+                },
+              },
+              fragments: [{ type: 'header', path: 'data.header' }],
+            }),
+          },
+          fragments: {
+            header: {
+              avatar: { name: 'loading....' },
+            },
+          },
+        })
+
+        await store.dispatch(saveAndProcessPage('/foo', page))
+        const state = store.getState()
+
+        expect(state.pages['/foo']).toEqual(
+          expect.objectContaining({
+            data: {
+              header: {
+                __id: 'header',
+              },
+            },
+          })
+        )
+
+        expect(state.fragments).toEqual({
+          header: {
+            avatar: {
+              name: 'John Smith',
+              contactDetails: { __id: 'personDetails' },
+            },
+          },
+          personDetails: {
+            address: {
+              zip: 10001,
+            },
+          },
+        })
+      })
+    })
+  })
+})

--- a/superglue/spec/lib/reducers.spec.js
+++ b/superglue/spec/lib/reducers.spec.js
@@ -1,12 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import {
-  pageReducer,
-  superglueReducer,
-  graftNodeOntoPage,
-  updateSameFragmentsOnPage,
-  appendReceivedFragmentsOntoPage,
-  handleGraft,
-} from '../../lib/reducers'
+import { pageReducer, superglueReducer } from '../../lib/reducers'
 
 describe('reducers', () => {
   describe('superglue reducer', () => {

--- a/superglue/spec/lib/stream_actions.spec.js
+++ b/superglue/spec/lib/stream_actions.spec.js
@@ -135,14 +135,15 @@ describe('Stream Actions', () => {
   })
 
   describe('handle', () => {
-    it('calls append with correct arguments', () => {
+    it('handles append action and updates fragments state', () => {
       const store = buildStore({
-        fragments: {},
+        fragments: {
+          foo: []
+        },
         superglue: { currentPageKey: '/posts' },
       })
       const actions = new StreamActions({ store, remote: vi.fn() })
 
-      const stub = vi.spyOn(actions, 'append').mockImplementation(() => {})
       const msg = JSON.stringify({
         type: 'message',
         action: 'append',
@@ -153,17 +154,22 @@ describe('Stream Actions', () => {
       })
 
       actions.handle(msg, '/posts')
-      expect(stub).toHaveBeenCalledWith(['foo'], { id: 1 }, {})
+      
+      const nextState = store.getState()
+      expect(nextState.fragments).toEqual({
+        foo: [{ id: 1 }],
+      })
     })
 
-    it('calls prepend with correct arguments', () => {
+    it('handles prepend action and updates fragments state', () => {
       const store = buildStore({
-        fragments: {},
+        fragments: {
+          bar: [{ id: 0 }]
+        },
         superglue: { currentPageKey: '/posts' },
       })
       const actions = new StreamActions({ store, remote: vi.fn() })
 
-      const stub = vi.spyOn(actions, 'prepend').mockImplementation(() => {})
       const msg = JSON.stringify({
         type: 'message',
         action: 'prepend',
@@ -174,17 +180,20 @@ describe('Stream Actions', () => {
       })
 
       actions.handle(msg, '/posts')
-      expect(stub).toHaveBeenCalledWith(['bar'], { id: 2 }, {})
+      
+      const nextState = store.getState()
+      expect(nextState.fragments).toEqual({
+        bar: [{ id: 2 }, { id: 0 }],
+      })
     })
 
-    it('calls save with correct arguments', () => {
+    it('handles save action and updates fragments state', () => {
       const store = buildStore({
         fragments: {},
         superglue: { currentPageKey: '/posts' },
       })
       const actions = new StreamActions({ store, remote: vi.fn() })
 
-      const stub = vi.spyOn(actions, 'save').mockImplementation(() => {})
       const msg = JSON.stringify({
         type: 'message',
         action: 'save',
@@ -195,7 +204,11 @@ describe('Stream Actions', () => {
       })
 
       actions.handle(msg, '/posts')
-      expect(stub).toHaveBeenCalledWith('baz', { id: 3 })
+      
+      const nextState = store.getState()
+      expect(nextState.fragments).toEqual({
+        baz: { id: 3 },
+      })
     })
 
     it('calls refresh if page keys match', () => {
@@ -238,12 +251,13 @@ describe('Stream Actions', () => {
 
     it('denormalizes fragments from message and stores them in fragments slice', () => {
       const store = buildStore({
-        fragments: {},
+        fragments: {
+          posts: []
+        },
         superglue: { currentPageKey: '/posts' },
       })
       const actions = new StreamActions({ store, remote: vi.fn() })
 
-      const stub = vi.spyOn(actions, 'append').mockImplementation(() => {})
       const msg = JSON.stringify({
         type: 'message',
         action: 'append',
@@ -273,13 +287,10 @@ describe('Stream Actions', () => {
         header: {
           avatar: { __id: 'user' },
         },
+        posts: [{
+          header: { __id: 'header' },
+        }],
       })
-
-      expect(stub).toHaveBeenCalledWith(['posts'], {             
-        header: {
-         __id: 'header',
-        } 
-      }, {})
     })
 
     it('skips fragment processing for refresh actions', () => {

--- a/superglue/spec/lib/stream_actions.spec.js
+++ b/superglue/spec/lib/stream_actions.spec.js
@@ -1,0 +1,309 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { rootReducer } from '../../lib'
+
+import { StreamActions } from '../../lib/hooks/useStreamSource'
+import { describe, expect, afterEach, beforeEach, it, vi } from 'vitest'
+
+const buildStore = (preloadedState) => {
+  let resultsReducer = (state = [], action) => {
+    return state.concat([action])
+  }
+
+  return configureStore({
+    preloadedState,
+    reducer: {
+      ...rootReducer,
+      results: resultsReducer,
+    },
+  })
+}
+
+describe('Stream Actions', () => {
+  describe('save', () => {
+    it('saves the data to a fragment', () => {
+      const store = buildStore({
+        fragments: {},
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+      actions.save('post_1', { hello: 'world' })
+
+      const nextState = store.getState()
+
+      expect(nextState.fragments).toEqual({
+        post_1: { hello: 'world' },
+      })
+    })
+  })
+
+  describe('refresh', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('debouces a remote call', () => {
+      const store = buildStore({
+        fragments: {},
+      })
+      const remote = vi.fn()
+
+      const actions = new StreamActions({ store, remote})
+      actions.refresh('/posts')
+      expect(remote).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(300)
+
+      expect(remote).toHaveBeenCalledWith('/posts')
+    })
+  })
+
+  describe('append', () => {
+    it('appends data to a fragment', () => {
+      const store = buildStore({
+        fragments: {
+          posts: [{ hello: 'john' }],
+        },
+      })
+
+      const actions = new StreamActions({ store, remote: vi.fn() })
+      actions.append(['posts'], { hello: 'world' })
+
+      const nextState = store.getState()
+
+      expect(nextState.fragments).toEqual({
+        posts: [{ hello: 'john' }, { hello: 'world' }],
+      })
+    })
+
+    it('appends a fragment to a fragment', () => {
+      const store = buildStore({
+        fragments: {
+          posts: [{ hello: 'john' }],
+        },
+      })
+
+      const actions = new StreamActions({ store, remote: vi.fn() })
+      actions.append(['posts'], { hello: 'world' }, { saveAs: 'post_2' })
+
+      const nextState = store.getState()
+
+      expect(nextState.fragments).toEqual({
+        posts: [{ hello: 'john' }, { __id: 'post_2' }],
+        post_2: { hello: 'world' },
+      })
+    })
+  })
+
+  describe('prepend', () => {
+    it('prepends data to a fragment', () => {
+      const store = buildStore({
+        fragments: {
+          posts: [{ hello: 'john' }],
+        },
+      })
+
+      const actions = new StreamActions({ store, remote: vi.fn() })
+      actions.prepend(['posts'], { hello: 'world' })
+
+      const nextState = store.getState()
+
+      expect(nextState.fragments).toEqual({
+        posts: [{ hello: 'world' }, { hello: 'john' }],
+      })
+    })
+
+    it('prepends a fragment to a fragment', () => {
+      const store = buildStore({
+        fragments: {
+          posts: [{ hello: 'john' }],
+        },
+      })
+
+      const actions = new StreamActions({ store, remote: vi.fn() })
+      actions.prepend(['posts'], { hello: 'world' }, { saveAs: 'post_2' })
+
+      const nextState = store.getState()
+
+      expect(nextState.fragments).toEqual({
+        posts: [{ __id: 'post_2' }, { hello: 'john' }],
+        post_2: { hello: 'world' },
+      })
+    })
+  })
+
+  describe('handle', () => {
+    it('calls append with correct arguments', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: '/posts' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'append').mockImplementation(() => {})
+      const msg = JSON.stringify({
+        type: 'message',
+        action: 'append',
+        fragmentKeys: ['foo'],
+        data: { id: 1 },
+        options: {},
+        fragments: []
+      })
+
+      actions.handle(msg, '/posts')
+      expect(stub).toHaveBeenCalledWith(['foo'], { id: 1 }, {})
+    })
+
+    it('calls prepend with correct arguments', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: '/posts' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'prepend').mockImplementation(() => {})
+      const msg = JSON.stringify({
+        type: 'message',
+        action: 'prepend',
+        fragmentKeys: ['bar'],
+        data: { id: 2 },
+        options: {},
+        fragments: []
+      })
+
+      actions.handle(msg, '/posts')
+      expect(stub).toHaveBeenCalledWith(['bar'], { id: 2 }, {})
+    })
+
+    it('calls save with correct arguments', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: '/posts' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'save').mockImplementation(() => {})
+      const msg = JSON.stringify({
+        type: 'message',
+        action: 'save',
+        fragmentKeys: ['baz'],
+        data: { id: 3 },
+        options: {},
+        fragments: []
+      })
+
+      actions.handle(msg, '/posts')
+      expect(stub).toHaveBeenCalledWith('baz', { id: 3 })
+    })
+
+    it('calls refresh if page keys match', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: '/posts' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'refresh').mockImplementation(() => {})
+      const msg = JSON.stringify({ 
+        type: 'message', 
+        action: 'refresh',
+        requestId: 'test-request-id',
+        options: {}
+      })
+
+      actions.handle(msg, '/posts')
+      expect(stub).toHaveBeenCalledWith('/posts')
+    })
+
+    it('does not call refresh if page keys do not match', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: 'page_2' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'refresh').mockImplementation(() => {})
+      const msg = JSON.stringify({ 
+        type: 'message', 
+        action: 'refresh',
+        requestId: 'test-request-id',
+        options: {}
+      })
+
+      actions.handle(msg, '/posts')
+      expect(stub).not.toHaveBeenCalled()
+    })
+
+    it('denormalizes fragments from message and stores them in fragments slice', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: '/posts' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'append').mockImplementation(() => {})
+      const msg = JSON.stringify({
+        type: 'message',
+        action: 'append',
+        fragmentKeys: ['posts'],
+        data: {
+          header: {
+            avatar: {
+              name: 'John Smith',
+            },
+          },
+        },
+        options: {},
+        fragments: [
+          { type: 'header', path: 'data.header' },
+          { type: 'user', path: 'data.header.avatar' },
+        ]
+      })
+
+      actions.handle(msg, '/posts')
+
+      const nextState = store.getState()
+
+      expect(nextState.fragments).toEqual({
+        user: {
+          name: 'John Smith',
+        },
+        header: {
+          avatar: { __id: 'user' },
+        },
+      })
+
+      expect(stub).toHaveBeenCalledWith(['posts'], {             
+        header: {
+         __id: 'header',
+        } 
+      }, {})
+    })
+
+    it('skips fragment processing for refresh actions', () => {
+      const store = buildStore({
+        fragments: {},
+        superglue: { currentPageKey: '/posts' },
+      })
+      const actions = new StreamActions({ store, remote: vi.fn() })
+
+      const stub = vi.spyOn(actions, 'refresh').mockImplementation(() => {})
+      const msg = JSON.stringify({
+        type: 'message',
+        action: 'refresh',
+        requestId: 'test-request-id',
+        options: {},
+      })
+
+      actions.handle(msg, '/posts')
+
+      const nextState = store.getState()
+
+      // Fragments should remain empty since refresh actions skip fragment processing
+      expect(nextState.fragments).toEqual({})
+      expect(stub).toHaveBeenCalledWith('/posts')
+    })
+  })
+})

--- a/superglue/spec/lib/utils/request.spec.js
+++ b/superglue/spec/lib/utils/request.spec.js
@@ -63,6 +63,7 @@ describe('argsForFetch', () => {
         method: 'GET',
         headers: {
           accept: 'application/json',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-requested-with': 'XMLHttpRequest',
           'x-superglue-request': 'true',
         },
@@ -89,6 +90,7 @@ describe('argsForFetch', () => {
         method: 'GET',
         headers: {
           accept: 'application/json',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-requested-with': 'XMLHttpRequest',
           'x-superglue-request': 'true',
         },
@@ -114,6 +116,7 @@ describe('argsForFetch', () => {
         headers: {
           accept: 'application/json',
           'x-requested-with': 'XMLHttpRequest',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-superglue-request': 'true',
           'content-type': 'application/json',
           'x-http-method-override': 'PUT',
@@ -142,6 +145,7 @@ describe('argsForFetch', () => {
         method: 'GET',
         headers: {
           accept: 'application/json',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-requested-with': 'XMLHttpRequest',
           'x-superglue-request': 'true',
         },
@@ -167,6 +171,7 @@ describe('argsForFetch', () => {
         method: 'GET',
         headers: {
           accept: 'application/json',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-requested-with': 'XMLHttpRequest',
           'x-superglue-request': 'true',
         },
@@ -186,6 +191,7 @@ describe('argsForFetch', () => {
         method: 'HEAD',
         headers: {
           accept: 'application/json',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-requested-with': 'XMLHttpRequest',
           'x-superglue-request': 'true',
         },
@@ -213,6 +219,7 @@ describe('argsForFetch', () => {
         method: 'GET',
         headers: {
           accept: 'application/json',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-requested-with': 'XMLHttpRequest',
           'x-superglue-request': 'true',
         },
@@ -233,6 +240,7 @@ describe('argsForFetch', () => {
         headers: {
           accept: 'application/json',
           'x-requested-with': 'XMLHttpRequest',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-superglue-request': 'true',
         },
         signal: undefined,
@@ -264,6 +272,7 @@ describe('argsForFetch', () => {
         headers: {
           accept: 'application/json',
           'x-requested-with': 'XMLHttpRequest',
+          'X-Superglue-Request-Id': expect.any(String),
           'x-superglue-request': 'true',
         },
         signal: undefined,

--- a/superglue/spec/support/store.jsx
+++ b/superglue/spec/support/store.jsx
@@ -1,0 +1,13 @@
+const buildStore = (preloadedState) => {
+  let resultsReducer = (state = [], action) => {
+    return state.concat([action])
+  }
+
+  return configureStore({
+    preloadedState,
+    reducer: {
+      ...rootReducer,
+      results: resultsReducer,
+    },
+  })
+}


### PR DESCRIPTION
This allows for a rails controller action like `create` (those that mutate) to render a view with just the fragments needed to update the referring page. There's no special vnd content type. Its all json and a render away.

Usage:

```
def create
  ...
  if @post.save
    redirect_to :back
  else
    render :create
  end
end
```

and in create.json.props

```
superglue.broadcast_save_to_props(@post)
```

Would update the fragment and leave the current page url untouched.