### PR TITLE
Correct link to SSR docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ For more on what you can do, check out our documentation.
 Server-Side Rendering is supported via [Humid](https://github.com/thoughtbot/humid).
 See the [documentation for server-side rendering][ssr docs].
 
-  [ssr docs]: ./recipes/server-side-rendering.md
+  [ssr docs]: ./docs/recipes/ssr.md
 
 ## Documentation
 


### PR DESCRIPTION
There was a typo in the README to the SSR docs. This corrected it.