### PR TITLE
Typo: Fix missing space fromthe to from the

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -122,7 +122,7 @@ export default function FooBar() {
 
 ### It’s Turbolinks
 
-Superglue drew inspiration fromthe original Turbolinks, but instead of sending
+Superglue drew inspiration from the original Turbolinks, but instead of sending
 your `foobar.html.erb` over the wire and swapping the `<body>`, it sends
 `foobar.json.props` over the wire to your React and Redux app and swaps the
 page component.


### PR DESCRIPTION
<img width="830" height="316" alt="image" src="https://github.com/user-attachments/assets/2072c2b8-88c4-48c8-8373-6556c480dec0" />
