### PR TITLE
Expose the JSON response from SuperglueResponseError

### DIFF
--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -21,7 +21,6 @@ function downloadingFile(xhr: Response): boolean {
 
 class SuperglueResponseError extends Error {
   response: Response
-  json: unknown
 
   constructor(message: string) {
     super(message)
@@ -30,19 +29,18 @@ class SuperglueResponseError extends Error {
 }
 
 export function validateResponse(args: ParsedResponse): ParsedResponse {
-  const { rsp, json } = args
+  const { rsp } = args
   if (isValidResponse(rsp)) {
     return args
   } else {
     const error = new SuperglueResponseError('Invalid Superglue Response')
     error.response = rsp
-    error.json = json
     throw error
   }
 }
 
 export function handleServerErrors(args: ParsedResponse): ParsedResponse {
-  const { rsp, json } = args
+  const { rsp } = args
   if (!rsp.ok && rsp.status !== 422) {
     if (rsp.status === 406) {
       console.error(
@@ -56,7 +54,6 @@ export function handleServerErrors(args: ParsedResponse): ParsedResponse {
     }
     const error = new SuperglueResponseError(rsp.statusText)
     error.response = rsp
-    error.json = json
     throw error
   }
   return args
@@ -137,6 +134,7 @@ export function argsForFetch(
 
 export function extractJSON(rsp: Response): PromiseLike<ParsedResponse> {
   return rsp
+    .clone()
     .json()
     .then((json) => {
       return { rsp, json }


### PR DESCRIPTION
Hi there,

I've noticed an issue with error handling in the `visit` in superglue.

## The problem
In my application_visit.ts I wanted to capture a response error and show the error inside a modal, instead of redirecting to window.location.href = '/500.html';

The problem is that, when processing the `fetch` request internally, you are already fetching the `request.json()` body, so, even if you return the response object, the actual body is totally inaccessible from there.

Example:

```typescript
//... Rest of the code ....
      .catch((err) => {
        const response = err.response as Response | undefined;

        if (!response) {
          console.error(err);
          return;
        }

        if (response.ok) {
          window.location.href = response.url;
        } else {
          if (response.status >= 400) {
            console.log(await response.json()); /// <---- HERE IS CRASHING `WITH Uncaught (in promise) TypeError: Failed to execute 'text' on 'Response': body stream already read`
            return;
          }
        }
      });
  };
};
```

## Proposed Solution

Since you are already extracting the body of the response internally, why not returning it as a part of `SuperglueResponseError`?

