### PR TITLE
Fix optimistic update crash when following v2 docs

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1192,7 +1192,7 @@ For the final touch, let's add optimistic updates using `useSetFragment`:
           name,
           completed,
           detailPath,
-          toggleForm,
+    -     toggleForm,
         } = useContent(itemRef)
     +   const set = useSetFragment()
     +   const { remote } = useContext(NavigationContext)


### PR DESCRIPTION
Without this change, the following crash was observed locally when clicking the `toggle` button in the ItemsList component

```
Uncaught TypeError: 'get' on proxy: property 'toggleForm' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '#<Object>' but got '#<Object>')
    at Item (ItemsList.tsx:10:9)
    at Object.react_stack_bottom_frame (react-dom_client.js?v=308ae0de:18763:20)
    at renderWithHooks (react-dom_client.js?v=308ae0de:5908:24)
    at updateFunctionComponent (react-dom_client.js?v=308ae0de:7729:21)
    at beginWork (react-dom_client.js?v=308ae0de:8779:20)
    at runWithFiberInDEV (react-dom_client.js?v=308ae0de:1251:72)
    at performUnitOfWork (react-dom_client.js?v=308ae0de:12815:98)
    at workLoopSync (react-dom_client.js?v=308ae0de:12678:43)
    at renderRootSync (react-dom_client.js?v=308ae0de:12662:13)
    at performWorkOnRoot (react-dom_client.js?v=308ae0de:12081:37)
```