### PR TITLE
Use app selector in form docs

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -104,7 +104,9 @@ end
 ```
 
 ```jsx
-const validationErrors = useSelector((state) => state.flash[:postFormErrors])
+import { useAppSelector } from '@javascript/store'
+
+const validationErrors = useAppSelector((state) => state.flash.postFormErrors)
 
 <Form {...form} extras={extras} validationErrors={validationErrors}>
   <TextField {...inputs.title} label="Post title" errorKey="post_title"/>


### PR DESCRIPTION
Just updating the docs to not have Ruby syntax as part of the JavaScript code snippet, and update the code to reference the `UseAppSelector` that I think is meant to be used in this context