### PR TITLE
Update vite recipe with guard

### DIFF
--- a/docs/recipes/vite.md
+++ b/docs/recipes/vite.md
@@ -54,6 +54,9 @@ const pages = import.meta.glob('../views/**/*.jsx', {eager: true})
 for (const key in pages) {
   if (pages.hasOwnProperty(key)) {
     const identifier = key.replace("../views/", "").split('.')[0];
+    if (!pages[key].default) {
+      throw new Error(`View ${identifier} did not export default component`)
+    } 
     pageIdentifierToPageComponent[identifier] = pages[key].default;
   }
 }


### PR DESCRIPTION
I was hitting a local issue where I created a new view component but incorrectly didn't export it by default; as a result superglue was giving a unexpected errors that took a few seconds to track down: 

```
@thoughtbot_superglue.js?v=842a6841:6550 Uncaught Error: Superglue Nav component was looking for ascents/new but could not find it in your mapping. 
    at notFound 
```

Now there is an upfront error that should be easier to track down:

```
Uncaught Error: View ascents/new did not export default component
    at page_to_page_mapping.ts:8:19
(anonymous) @ page_to_page_mapping.ts:8
```

This change might help a future developer, but happy for it to be closed if it's not quite right :+1: