### PR TITLE
Fix accidental frozen obj

### DIFF
--- a/superglue/lib/hooks/useSetFragment.tsx
+++ b/superglue/lib/hooks/useSetFragment.tsx
@@ -1,9 +1,12 @@
 import { useDispatch, useSelector } from 'react-redux'
-import { produce } from 'immer'
+import { Immer } from 'immer'
 import { saveFragment } from '../actions'
 import { RootState, Fragment } from '../types'
 import { Unproxy } from '../types'
 import { FragmentProxy } from './useContent'
+
+const immer = new Immer()
+immer.setAutoFreeze(false)
 
 /**
  * Utility type to extract the data type from a Fragment wrapper
@@ -75,7 +78,7 @@ export function useSetFragment() {
       throw new Error(`Fragment with id "${fragmentId}" not found`)
     }
 
-    const updatedFragment = produce(currentFragment, updater)
+    const updatedFragment = immer.produce(currentFragment, updater)
 
     dispatch(
       saveFragment({

--- a/superglue/spec/lib/useSetFragment.spec.jsx
+++ b/superglue/spec/lib/useSetFragment.spec.jsx
@@ -51,13 +51,14 @@ describe('useSetFragment', () => {
         })
       })
 
-      // Verify the fragment was updated in the store
       const updatedState = store.getState()
       expect(updatedState.fragments['user_123']).toEqual({
         id: 123,
         name: 'Jane',
         email: 'john@example.com',
       })
+
+      expect(Object.isFrozen(updatedState.fragments['user_123'])).toBe(false)
     })
 
     it('should update existing fragment with string reference', () => {
@@ -83,19 +84,19 @@ describe('useSetFragment', () => {
       const set = result.current
 
       act(() => {
-        // Using string directly instead of object
         set('user_123', (draft) => {
           draft.name = 'Jane'
         })
       })
 
-      // Verify the fragment was updated in the store
       const updatedState = store.getState()
       expect(updatedState.fragments['user_123']).toEqual({
         id: 123,
         name: 'Jane',
         email: 'john@example.com',
       })
+
+      expect(Object.isFrozen(updatedState.fragments['user_123'])).toBe(false)
     })
 
     it('should handle nested object updates', () => {
@@ -184,7 +185,6 @@ describe('useSetFragment', () => {
       const set = result.current
 
       act(() => {
-        // Using string directly
         set('posts_collection', (draft) => {
           draft.push({ title: 'Post 3' })
         })
@@ -229,7 +229,6 @@ describe('useSetFragment', () => {
         set({ __id: 'user_123' }, (userDraft) => {
           userDraft.name = 'Jane'
 
-          // Nested set call
           set(userDraft.profile, (profileDraft) => {
             profileDraft.avatar = '/new.jpg'
           })


### PR DESCRIPTION
When using `useSetFragment`, the obj returned was frozen. This cause a javascript invariant violation which breaks the proxy leading to this error discovered on

https://github.com/thoughtbot/superglue/pull/173

```
Uncaught TypeError: 'get' on proxy: property 'toggleForm' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected '#<Object>' but got '#<Object>')
    at Item (ItemsList.jsx:11:5)
    at Object.react_stack_bottom_frame (react-dom-client.development.js:23863:20)
... etc ..
```

The fix is to use a local instance of Immer and setting the auto freeze to false.