### PR TITLE
Fix pagination docs typo

### DIFF
--- a/docs/recipes/spa-pagination.md
+++ b/docs/recipes/spa-pagination.md
@@ -103,7 +103,7 @@ methods return `nil` if there are no subsequent pages.
 
     def index
       @posts = Post.all
-    +   .page(params[:page_num])
+    +   .page(params[:page])
     +   .per(10)
     +   .order(created_at: :desc)
     end


### PR DESCRIPTION
This recipe makes use of the `kaminari` gem for pagination which generates links with the `page` query parameter rather than `per_num`. Potentially the [props-template docs](https://github.com/thoughtbot/superglue/blob/3651080b6f2cfa869306ea0f3883fb83b2b112d8/docs/props-template.md#example) could be updated for consistency