### PR TITLE
Fix lodash import

### DIFF
--- a/superglue/lib/hooks/useStreamSource.tsx
+++ b/superglue/lib/hooks/useStreamSource.tsx
@@ -6,7 +6,8 @@ import {
 import { useState, useEffect, useRef, createContext, useContext } from 'react'
 import { ApplicationRemote, FragmentPath } from '../types'
 import { useSuperglue } from '.'
-import { debounce, DebouncedFunc } from 'lodash'
+import debounce from 'lodash.debounce'
+import type { DebouncedFunc } from 'lodash'
 import { lastRequestIds } from '../utils'
 import {
   streamPrepend,


### PR DESCRIPTION
This fixes an requirejs error reported by #182. It was caused by an improper lodash debounce import. Instead of loading the entire library, we just needed the debounce function.

This also reduced the entire library size from 200kb to about 18kb.