### PR TITLE
Move mock-socket to dev dependency

### DIFF
--- a/superglue/package.json
+++ b/superglue/package.json
@@ -69,6 +69,7 @@
     "fetch-headers": "^2.0.0",
     "fetch-mock": "^9.11.0",
     "jsdom": "^24.1.0",
+    "mock-socket": "^2.0.0",
     "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.1",
@@ -87,10 +88,10 @@
     "vitest": "^2.0.2"
   },
   "peerDependencies": {
+    "@deepkit/type-compiler": "^1.0.19",
     "@reduxjs/toolkit": "^2.2.8",
     "react": "^18 || ^19",
-    "react-redux": "^9 || ^8",
-    "@deepkit/type-compiler": "^1.0.19"
+    "react-redux": "^9 || ^8"
   },
   "peerDependenciesMeta": {
     "@deepkit/type-compiler": {
@@ -105,7 +106,6 @@
     "history": "^5.3.0",
     "immer": "^10.0.3",
     "lodash.debounce": "^4.0.8",
-    "mock-socket": "^2.0.0",
     "uuid": "^11.1.0"
   }
 }


### PR DESCRIPTION
Moves the test dependency `mock-socket` dependency to `devDependencies` to avoid false positives in vulnerability scanning tools like Snyk when depending on the superglue library, which does not like the old mock-uri 2.0.0 version depending on urijs which vulnerabilities associated with it:

```
$ yarn why urijs
...
=> Found "urijs@1.17.1"
info Reasons this module exists
   - "@thoughtbot#superglue#mock-socket" depends on it
   - Hoisted from "@thoughtbot#superglue#mock-socket#urijs"
```

I did also briefly look at the effort required to update the dependency, it looks like `.send` was removed from the mock-socket server API, and you need a socket instance instead from what I saw at glance - so it should be possible to update in the future