### PR TITLE
Make deepkit an optional peer

### DIFF
--- a/superglue/lib/hooks/useContent.tsx
+++ b/superglue/lib/hooks/useContent.tsx
@@ -1,7 +1,12 @@
 import { useSelector, useStore } from 'react-redux'
 import { useMemo, useRef } from 'react'
-import { ReceiveType, resolveReceiveType, validate } from '@deepkit/type'
-import { JSONMappable, RootState, Unproxy, FragmentRef } from '../types'
+import {
+  JSONMappable,
+  RootState,
+  Unproxy,
+  FragmentRef,
+  ReceiveType,
+} from '../types'
 import { useSuperglue } from './index'
 import { createProxy, unproxy as unproxyUtil } from '../utils/proxy'
 
@@ -150,21 +155,30 @@ export function useContent<T = JSONMappable>(
         new WeakMap()
       ) as T
 
-      const resolvedType = resolveReceiveType(__type)
-      const errors = validate(proxyForValidation, resolvedType)
+      import('@deepkit/type')
+        .then(({ resolveReceiveType, validate }) => {
+          // @ts-expect-error - ReceiveType<T> is transformed by Deepkit compiler
+          const resolvedType = resolveReceiveType(__type)
+          const errors = validate(proxyForValidation, resolvedType)
 
-      if (errors.length > 0) {
-        const formattedErrors = errors.map((e) => ({
-          path: e.path,
-          message: e.message,
-          code: String(e.code),
-        }))
+          if (errors.length > 0) {
+            const formattedErrors = errors.map((e) => ({
+              path: e.path,
+              message: e.message,
+              code: String(e.code),
+            }))
 
-        console.error(
-          `[Superglue] Content validation failed for ${fragmentId || 'page'}:`,
-          formattedErrors
-        )
-      }
+            console.error(
+              `[Superglue] Content validation failed for ${
+                fragmentId || 'page'
+              }:`,
+              formattedErrors
+            )
+          }
+        })
+        .catch(() => {
+          // Deepkit not installed - silently skip validation
+        })
     }
 
     return proxy

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -14,6 +14,15 @@ import { rootReducer } from '../reducers'
 import { FragmentProxy } from '../hooks/useContent'
 
 export * from './requests'
+
+/**
+ * Type marker for Deepkit runtime validation. This allows Deepkit
+ * to be an optional peer dependency since Deepkit only checks for
+ * the name of the type is ReceiveType.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type ReceiveType<T> = unknown
+
 /**
  * A PageKey is a combination of a parsed URL's pathname + query string. No hash.
  *

--- a/superglue/package.json
+++ b/superglue/package.json
@@ -52,6 +52,8 @@
   },
   "homepage": "https://github.com/thoughtbot/superglue#readme",
   "devDependencies": {
+    "@deepkit/core": "^1.0.19",
+    "@deepkit/type": "^1.0.19",
     "@deepkit/type-compiler": "^1.0.19",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",
@@ -88,18 +90,25 @@
     "vitest": "^2.0.2"
   },
   "peerDependencies": {
+    "@deepkit/core": "^1.0.19",
+    "@deepkit/type": "^1.0.19",
     "@deepkit/type-compiler": "^1.0.19",
     "@reduxjs/toolkit": "^2.2.8",
     "react": "^18 || ^19",
     "react-redux": "^9 || ^8"
   },
   "peerDependenciesMeta": {
+    "@deepkit/core": {
+      "optional": true
+    },
+    "@deepkit/type": {
+      "optional": true
+    },
     "@deepkit/type-compiler": {
       "optional": true
     }
   },
   "dependencies": {
-    "@deepkit/type": "^1.0.19",
     "@rails/actioncable": "^8.0.200",
     "@types/lodash.debounce": "^4.0.9",
     "@types/rails__actioncable": "^6.1.11",

--- a/superglue/tsconfig.json
+++ b/superglue/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "removeComments": true,
+    "module": "ES2020",
     "moduleResolution": "Node",
     "strict": true,
     "strictPropertyInitialization": false,


### PR DESCRIPTION
I'm making deepkit an optional peer dependency. If there's a need for runtime type checking, devs will need to install it by themselves.