### PR TITLE
Make `beforeSave` easier to work with

### DIFF
--- a/docs/requests.md
+++ b/docs/requests.md
@@ -128,15 +128,14 @@ sequenceDiagram
 ## The `beforeSave` callback
 
 !!! note
-    `beforeSave` is an advanced Supeglue feature. Before proceeding please familiarize
+    `beforeSave` is an advanced Superglue feature. Before proceeding please familiarize
     yourself with:
 
     1. Knowing how [Fragments and FragmentRefs](./fragments.md) work, the first
     parameter passed to `beforeSave` is a proxy that lazily normalizes
     fragments.
-    2. How to get the [unproxied](./performance.md#stable-references-with-unproxy) state.
-    3. Knowing the shape of [savePage or graft](./page-response.md) responses.
-    4. Knowing how [denormaliztion](./fragments.md#denormalization) works 
+    2. Knowing the shape of [savePage or graft](./page-response.md) responses.
+    3. Knowing how [denormaliztion](./fragments.md#denormalization) works 
 
 Both `visit` and `remote` can be passed a `beforeSave` callback. This is your 
 opportunity to modify the incoming [savePage or graft](./page-response.md)
@@ -179,9 +178,11 @@ remote("/posts", {beforeSave})
       json.body post.body
     ```
 
-    be sure to use the [key](./props-template.md#working-with-arrays) to help Superglue
-    identify fragments in the concatenated array.
-
+    be sure to use the [key](./props-template.md#working-with-arrays) to help
+    Superglue identify fragments in the concatenated array. Otherwise, any
+    index based fragment array's in `receivedResponse` will be frozen to prevent
+    mutations.
+    
     `_post_list.json.props`
     
     ```diff

--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -115,15 +115,18 @@ export function saveAndProcessPage(
       .reverse()
       .forEach((fragment) => {
         const { id, path } = fragment
-        const node = getIn(nextPage, path) as JSONMappable
-        nextPage = setIn(nextPage, path, { __id: id })
+        const node = getIn(nextPage, path) as JSONMappable | undefined
 
-        dispatch(
-          saveFragment({
-            fragmentId: id,
-            data: node,
-          })
-        )
+        if (node && !(typeof node === 'object' && '__id' in node)) {
+          nextPage = setIn(nextPage, path, { __id: id })
+
+          dispatch(
+            saveFragment({
+              fragmentId: id,
+              data: node,
+            })
+          )
+        }
       })
 
     if (nextPage.action === 'graft') {

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -29,8 +29,71 @@ import {
   NavigationAction,
   VisitMeta,
   BeforeSave,
+  AllFragments,
+  GraftResponse,
+  SaveResponse,
+  JSONMappable,
 } from '../types'
 import { createProxy } from '../utils/proxy'
+
+export function preparePageForSave<T extends JSONMappable = JSONMappable>(
+  nextPage: GraftResponse<T> | SaveResponse<T>,
+  prevPage: Page<T> | undefined,
+  prevFragments: AllFragments,
+  beforeSave: BeforeSave<T>
+): GraftResponse<T> | SaveResponse<T> {
+  const existingPage = prevPage
+    ? createProxy(
+        prevPage,
+        { current: prevFragments },
+        new Set(),
+        new WeakMap()
+      )
+    : undefined
+
+  nextPage.fragments
+    .slice()
+    .reverse()
+    .forEach((fragment) => {
+      const { path } = fragment
+
+      dangerouslyEachIn(nextPage, path, (child, key, nextKey) => {
+        if (Array.isArray(child) && key && !key.includes('=')) {
+          Object.freeze(child)
+        }
+
+        if (nextKey && !nextKey.includes('=') && parseInt(nextKey)) {
+          if (Array.isArray(child)) {
+            Object.defineProperty(child, nextKey, {
+              writable: false,
+              configurable: false,
+            })
+          }
+
+          if (
+            typeof child === 'object' &&
+            child !== null &&
+            !Array.isArray(child)
+          ) {
+            Object.defineProperty(child, nextKey, {
+              writable: false,
+              configurable: false,
+            })
+          }
+        }
+      })
+    })
+
+  return JSON.parse(
+    JSON.stringify(beforeSave(existingPage, nextPage), (_key, value) => {
+      if (value && typeof value === 'object' && value.__id) {
+        return { __id: value.__id }
+      }
+
+      return value
+    })
+  ) as typeof nextPage
+}
 
 function handleFetchErr(
   err: Error,
@@ -141,19 +204,10 @@ the same page. Or if you're sure you want to proceed, use force: true.
           })
         )
 
-        const existingPage = createProxy(
-          pages[pageKey],
-          { current: fragments },
-          new Set(),
-          new WeakMap()
-        )
-
         let page = json
 
         if (json.action === 'savePage' || json.action === 'graft') {
-          page = JSON.parse(
-            JSON.stringify(beforeSave(existingPage, json))
-          ) as PageResponse
+          page = preparePageForSave(json, pages[pageKey], fragments, beforeSave)
         }
 
         return dispatch(saveAndProcessPage(pageKey, page)).then(() => meta)

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -6,6 +6,7 @@ import {
   hasPropsAt,
   propsAtParam,
   removePropsAt,
+  dangerouslyEachIn,
 } from '../utils'
 import {
   beforeFetch,

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -138,7 +138,7 @@ export class MismatchedComponentError extends Error {
   }
 }
 
-const defaultBeforeSave: BeforeSave = (prevPage, receivedPage) => receivedPage
+const defaultBeforeSave: BeforeSave = (prevPage, nextPage) => nextPage
 
 export const remote: RemoteCreator = (
   path,
@@ -227,7 +227,7 @@ export const visit: VisitCreator = (
   path,
   {
     placeholderKey,
-    beforeSave = (prevPage: Page, receivedPage: PageResponse) => receivedPage,
+    beforeSave = defaultBeforeSave,
     revisit = false,
     ...rest
   } = {}

--- a/superglue/lib/types/requests.ts
+++ b/superglue/lib/types/requests.ts
@@ -111,11 +111,15 @@ export interface BeforeSave<T = JSONMappable> {
    * useful for appending, prepending, shuffeling, etc. recieved data to
    * existing data.
    *
+   * `prevPage` is `undefined` when there is no existing page in the store
+   * (e.g. on a first visit).
+   *
    * ```
    * const beforeSave = (prevPage, nextPage) => {
+   *   const prevMessages = prevPage?.data?.messages ?? []
    *   nextPage.data.messages = [
-   *     prevPage.data.messages,
-   *     ... nextPage.data.messages
+   *     ...prevMessages,
+   *     ...nextPage.data.messages
    *   ]
    *
    *   return nextPage
@@ -126,8 +130,8 @@ export interface BeforeSave<T = JSONMappable> {
    */
 
   <U extends SaveResponse<T> | GraftResponse<T>>(
-    prevPage: Page<T>,
-    receivedPage: U
+    prevPage: Page<T> | undefined,
+    nextPage: U
   ): U
 }
 

--- a/superglue/lib/utils/immutability.ts
+++ b/superglue/lib/utils/immutability.ts
@@ -185,7 +185,11 @@ function setIn<T extends JSONMappable>(
 function dangerouslyEachIn(
   node: JSONMappable,
   path: Keypath,
-  visitor: (child: JSONValue, key: string | null, nextKey: string | null) => void
+  visitor: (
+    child: JSONValue,
+    key: string | null,
+    nextKey: string | null
+  ) => void
 ): void {
   const keyPath = normalizeKeyPath(path)
   let current: JSONValue = node

--- a/superglue/lib/utils/immutability.ts
+++ b/superglue/lib/utils/immutability.ts
@@ -173,4 +173,43 @@ function setIn<T extends JSONMappable>(
   return results[0]
 }
 
-export { getIn, setIn, KeyPathError }
+/**
+ * Walks a {@link Keypath} through a JSON object, calling a visitor at each
+ * node along the path. The visitor receives the raw reference and may mutate
+ * it (e.g. Object.freeze).
+ *
+ * @param node
+ * @param path
+ * @param visitor Called with (child, key, nextKey). key is null for the root node. nextKey is null for the last node.
+ */
+function dangerouslyEachIn(
+  node: JSONMappable,
+  path: Keypath,
+  visitor: (child: JSONValue, key: string | null, nextKey: string | null) => void
+): void {
+  const keyPath = normalizeKeyPath(path)
+  let current: JSONValue = node
+
+  visitor(current, null, keyPath[0] ?? null)
+
+  for (let i = 0; i < keyPath.length; i++) {
+    const key = keyPath[i]
+
+    if (typeof current === 'object' && current !== null) {
+      if (!Array.isArray(current) && canLookAhead.test(key)) {
+        throw new KeyPathError(
+          `Expected to find an Array when using the key: ${key}`
+        )
+      }
+
+      current = atKey(current, key)
+      visitor(current, key, keyPath[i + 1] ?? null)
+    } else {
+      throw new KeyPathError(
+        `Expected to traverse an Array or Obj, got ${JSON.stringify(current)}`
+      )
+    }
+  }
+}
+
+export { getIn, setIn, dangerouslyEachIn, KeyPathError }

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -323,6 +323,55 @@ describe('action creators', () => {
         })
     })
 
+    it('skips fragments whose path is already collapsed to an __id stub', () => {
+      const initialState = () => {
+        return {
+          pages: {
+            '/foo': {
+              data: {},
+              fragments: [],
+            },
+          },
+          fragments: {
+            sidebar_1: {
+              title: 'existing sidebar',
+              header: { text: 'existing header' },
+            },
+          },
+          superglue: {
+            currentPageKey: '/foo',
+            csrfToken: 'token',
+          },
+        }
+      }
+
+      const store = buildStore(initialState())
+
+      // Simulates the output of preparePageForSave after beforeSave copied
+      // a fragment ref from prevPage: data.sidebar is already {__id: 'sidebar_1'}
+      // but the fragments array still lists both parent and nested fragments.
+      const receivedPage = {
+        data: {
+          sidebar: { __id: 'sidebar_1' },
+        },
+        fragments: [
+          { id: 'sidebar_1', path: 'data.sidebar' },
+          { id: 'header_1', path: 'data.sidebar.header' },
+        ],
+        action: 'savePage',
+      }
+
+      return store
+        .dispatch(saveAndProcessPage('/foo', receivedPage))
+        .then(() => {
+          const saveFragmentActions = allSuperglueActions(store).filter(
+            (a) => a.type === '@@superglue/SAVE_FRAGMENT'
+          )
+
+          expect(saveFragmentActions).toEqual([])
+        })
+    })
+
     it('handles deferments on the page and fires HANDLE_GRAFT', () => {
       const store = buildStore({
         ...initialState(),

--- a/superglue/spec/lib/prepare_page_for_save.spec.js
+++ b/superglue/spec/lib/prepare_page_for_save.spec.js
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest'
+import { preparePageForSave } from '../../lib/action_creators/requests'
+
+describe('preparePageForSave', () => {
+  it('freezes arrays along fragment paths with numeric indices', () => {
+    const json = {
+      data: {
+        posts: [
+          { title: 'post 1', header: { text: 'hello' } },
+          { title: 'post 2', header: { text: 'world' } },
+        ],
+      },
+      action: 'savePage',
+      fragments: [{ id: 'header_1', path: 'data.posts.0.header' }],
+    }
+
+    const beforeSave = (prevPage, receivedPage) => {
+      expect(() => {
+        receivedPage.data.posts.push({ title: 'injected' })
+      }).toThrow(TypeError)
+
+      expect(() => {
+        receivedPage.data.posts[0] = { title: 'replaced' }
+      }).toThrow(TypeError)
+
+      return receivedPage
+    }
+
+    preparePageForSave(json, {}, {}, beforeSave)
+  })
+
+  it('freezes object properties pointing to numeric-indexed array elements', () => {
+    const json = {
+      data: {
+        container: {
+          items: [
+            { sidebar: { text: 'side 1' } },
+            { sidebar: { text: 'side 2' } },
+          ],
+        },
+      },
+      action: 'savePage',
+      fragments: [{ id: 'sidebar_1', path: 'data.container.items.1.sidebar' }],
+    }
+
+    const beforeSave = (prevPage, receivedPage) => {
+      expect(() => {
+        receivedPage.data.container.items[1] = { replaced: true }
+      }).toThrow(TypeError)
+
+      return receivedPage
+    }
+
+    preparePageForSave(json, {}, {}, beforeSave)
+  })
+
+  it('does not lock elements when fragment path uses id-based lookup', () => {
+    const json = {
+      data: {
+        items: [
+          { foo_id: 1, header: { text: 'hello' } },
+          { foo_id: 2, header: { text: 'world' } },
+        ],
+      },
+      action: 'savePage',
+      fragments: [{ id: 'header_2', path: 'data.items.foo_id=2.header' }],
+    }
+
+    const beforeSave = (prevPage, receivedPage) => {
+      expect(Object.isFrozen(receivedPage.data.items)).toBe(true)
+      expect(Object.isFrozen(receivedPage.data.items[1])).toBe(false)
+
+      return receivedPage
+    }
+
+    preparePageForSave(json, {}, {}, beforeSave)
+  })
+
+  it('preserves __id fragment references when beforeSave copies from existing page', () => {
+    const currentPage = {
+      data: {
+        sidebar: { __id: 'sidebar_1' },
+        posts: ['post 1'],
+      },
+      fragments: [{ id: 'sidebar_1', path: 'data.sidebar' }],
+    }
+    const currentFragments = { sidebar_1: { title: 'My Sidebar' } }
+
+    const json = {
+      data: {
+        sidebar: { title: 'New Sidebar' },
+        posts: ['post 2'],
+      },
+      action: 'savePage',
+      fragments: [{ id: 'sidebar_1', path: 'data.sidebar' }],
+    }
+
+    const beforeSave = (prevPage, receivedPage) => {
+      receivedPage.data.sidebar = prevPage.data.sidebar
+      return receivedPage
+    }
+
+    const result = preparePageForSave(json, currentPage, currentFragments, beforeSave)
+
+    expect(result).toEqual({
+      data: {
+        sidebar: { __id: 'sidebar_1' },
+        posts: ['post 2'],
+      },
+      action: 'savePage',
+      fragments: [{ id: 'sidebar_1', path: 'data.sidebar' }],
+    })
+  })
+
+  it('preserves nested __id references as top-level refs only', () => {
+    const currentPage = {
+      data: {
+        sidebar: { __id: 'sidebar_1' },
+      },
+      fragments: [
+        { id: 'sidebar_1', path: 'data.sidebar' },
+        { id: 'header_1', path: 'data.sidebar.header' },
+      ],
+    }
+    const currentFragments = {
+      sidebar_1: { title: 'My Sidebar', header: { __id: 'header_1' } },
+      header_1: { text: 'Header Text' },
+    }
+
+    const json = {
+      data: {
+        sidebar: {
+          title: 'New Sidebar',
+          header: { text: 'New Header' },
+        },
+      },
+      action: 'savePage',
+      fragments: [
+        { id: 'sidebar_1', path: 'data.sidebar' },
+        { id: 'header_1', path: 'data.sidebar.header' },
+      ],
+    }
+
+    const beforeSave = (prevPage, receivedPage) => {
+      receivedPage.data.sidebar = prevPage.data.sidebar
+      return receivedPage
+    }
+
+    const result = preparePageForSave(json, currentPage, currentFragments, beforeSave)
+
+    expect(result).toEqual({
+      data: {
+        sidebar: { __id: 'sidebar_1' },
+      },
+      action: 'savePage',
+      fragments: [
+        { id: 'sidebar_1', path: 'data.sidebar' },
+        { id: 'header_1', path: 'data.sidebar.header' },
+      ],
+    })
+  })
+
+  it('returns a plain object with no frozen properties', () => {
+    const json = {
+      data: {
+        posts: [
+          { title: 'post 1', header: { text: 'hello' } },
+        ],
+      },
+      action: 'savePage',
+      fragments: [{ id: 'header_1', path: 'data.posts.0.header' }],
+    }
+
+    const beforeSave = (_prevPage, receivedPage) => receivedPage
+
+    const result = preparePageForSave(json, {}, {}, beforeSave)
+
+    expect(result).toEqual({
+      data: {
+        posts: [
+          { title: 'post 1', header: { text: 'hello' } },
+        ],
+      },
+      action: 'savePage',
+      fragments: [{ id: 'header_1', path: 'data.posts.0.header' }],
+    })
+    expect(Object.isFrozen(result.data.posts)).toBe(false)
+  })
+
+  it('passes undefined as prevPage when there is no existing page', () => {
+    const json = {
+      data: {
+        posts: [{ title: 'post 1' }],
+      },
+      action: 'savePage',
+      fragments: [],
+    }
+
+    let receivedPrevPage = 'not called'
+    const beforeSave = (prevPage, receivedPage) => {
+      receivedPrevPage = prevPage
+      return receivedPage
+    }
+
+    preparePageForSave(json, undefined, {}, beforeSave)
+
+    expect(receivedPrevPage).toBeUndefined()
+  })
+})

--- a/superglue/spec/lib/prepare_page_for_save.spec.js
+++ b/superglue/spec/lib/prepare_page_for_save.spec.js
@@ -100,7 +100,12 @@ describe('preparePageForSave', () => {
       return receivedPage
     }
 
-    const result = preparePageForSave(json, currentPage, currentFragments, beforeSave)
+    const result = preparePageForSave(
+      json,
+      currentPage,
+      currentFragments,
+      beforeSave
+    )
 
     expect(result).toEqual({
       data: {
@@ -146,7 +151,12 @@ describe('preparePageForSave', () => {
       return receivedPage
     }
 
-    const result = preparePageForSave(json, currentPage, currentFragments, beforeSave)
+    const result = preparePageForSave(
+      json,
+      currentPage,
+      currentFragments,
+      beforeSave
+    )
 
     expect(result).toEqual({
       data: {
@@ -163,9 +173,7 @@ describe('preparePageForSave', () => {
   it('returns a plain object with no frozen properties', () => {
     const json = {
       data: {
-        posts: [
-          { title: 'post 1', header: { text: 'hello' } },
-        ],
+        posts: [{ title: 'post 1', header: { text: 'hello' } }],
       },
       action: 'savePage',
       fragments: [{ id: 'header_1', path: 'data.posts.0.header' }],
@@ -177,9 +185,7 @@ describe('preparePageForSave', () => {
 
     expect(result).toEqual({
       data: {
-        posts: [
-          { title: 'post 1', header: { text: 'hello' } },
-        ],
+        posts: [{ title: 'post 1', header: { text: 'hello' } }],
       },
       action: 'savePage',
       fragments: [{ id: 'header_1', path: 'data.posts.0.header' }],

--- a/superglue/spec/lib/utils/immutability.spec.js
+++ b/superglue/spec/lib/utils/immutability.spec.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { getIn, setIn, dangerouslyEachIn, KeyPathError } from '../../../lib/utils/immutability'
+import {
+  getIn,
+  setIn,
+  dangerouslyEachIn,
+  KeyPathError,
+} from '../../../lib/utils/immutability'
 
 describe('getIn', () => {
   it('fetches the node at keypath', () => {

--- a/superglue/spec/lib/utils/immutability.spec.js
+++ b/superglue/spec/lib/utils/immutability.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getIn, setIn, KeyPathError } from '../../../lib/utils/immutability'
+import { getIn, setIn, dangerouslyEachIn, KeyPathError } from '../../../lib/utils/immutability'
 
 describe('getIn', () => {
   it('fetches the node at keypath', () => {
@@ -111,5 +111,85 @@ describe('setIn', () => {
 
     expect(page.a[1]).toBe(clone.a[1])
     expect(clone).toEqual({ a: ['foo', { b: 5 }] })
+  })
+})
+
+describe('dangerouslyEachIn', () => {
+  it('visits root with null key, then each node with its keypath segment and nextKey', () => {
+    const page = { a: { b: { c: 5 } } }
+    const visited = []
+
+    dangerouslyEachIn(page, 'a.b', (child, key, nextKey) => {
+      visited.push({ child, key, nextKey })
+    })
+
+    expect(visited).toEqual([
+      { child: page, key: null, nextKey: 'a' },
+      { child: page.a, key: 'a', nextKey: 'b' },
+      { child: page.a.b, key: 'b', nextKey: null },
+    ])
+  })
+
+  it('works with array index keypaths', () => {
+    const page = { a: [{ b: 1 }, { b: 2 }] }
+    const visited = []
+
+    dangerouslyEachIn(page, 'a.1', (child, key, nextKey) => {
+      visited.push({ child, key, nextKey })
+    })
+
+    expect(visited).toEqual([
+      { child: page, key: null, nextKey: 'a' },
+      { child: page.a, key: 'a', nextKey: '1' },
+      { child: page.a[1], key: '1', nextKey: null },
+    ])
+  })
+
+  it('works with array attribute lookup', () => {
+    const page = { a: { b: [{ foo_id: 1 }, { foo_id: 2 }, { foo_id: 3 }] } }
+    const visited = []
+
+    dangerouslyEachIn(page, 'a.b.foo_id=2', (child, key, nextKey) => {
+      visited.push({ child, key, nextKey })
+    })
+
+    expect(visited).toEqual([
+      { child: page, key: null, nextKey: 'a' },
+      { child: page.a, key: 'a', nextKey: 'b' },
+      { child: page.a.b, key: 'b', nextKey: 'foo_id=2' },
+      { child: page.a.b[1], key: 'foo_id=2', nextKey: null },
+    ])
+  })
+
+  it('throws KeyPathError on non-traversable intermediate nodes', () => {
+    const page = { a: { b: 2 } }
+    expect(() => {
+      dangerouslyEachIn(page, 'a.b.c', () => {})
+    }).toThrow(new KeyPathError('Expected to traverse an Array or Obj, got 2'))
+  })
+
+  it('can be used to freeze nodes', () => {
+    const page = { a: { b: { c: 5 } } }
+
+    dangerouslyEachIn(page, 'a.b', (child) => {
+      if (typeof child === 'object' && child !== null) {
+        Object.freeze(child)
+      }
+    })
+
+    expect(Object.isFrozen(page)).toBe(true)
+    expect(Object.isFrozen(page.a)).toBe(true)
+    expect(Object.isFrozen(page.a.b)).toBe(true)
+  })
+
+  it('only visits root when path is empty', () => {
+    const page = { a: 1 }
+    const visited = []
+
+    dangerouslyEachIn(page, '', (child, key, nextKey) => {
+      visited.push({ child, key, nextKey })
+    })
+
+    expect(visited).toEqual([{ child: page, key: null, nextKey: null }])
   })
 })


### PR DESCRIPTION
  This PR makes beforeSave significantly easier and safer to work with by
  handling fragment normalization automatically and protecting against
  accidental mutation of fragment-backed data.

  Previously, writing a beforeSave callback meant juggling proxied fragments,
  knowing when to call unproxy, and being careful not to corrupt the normalized
  state. After this PR, you can write beforeSave as if it were plain JSON
  manipulation and Superglue handles the rest.