### PR TITLE
Add web specifc thunk.

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -19,6 +19,7 @@ import {
 import { handleStreamResponse } from './stream'
 import { createProxy } from '../utils/proxy'
 export * from './requests'
+export { webVisit, webRemote } from './web'
 
 function fetchDeferments(
   pageKey: string,

--- a/superglue/lib/action_creators/requests.ts
+++ b/superglue/lib/action_creators/requests.ts
@@ -22,12 +22,13 @@ import {
   PageResponse,
   Page,
   SuperglueState,
-  Meta,
+  Result,
+  ErrorResult,
   Dispatch,
   RemoteCreator,
   VisitCreator,
   NavigationAction,
-  VisitMeta,
+  VisitResult,
   BeforeSave,
   AllFragments,
   GraftResponse,
@@ -35,6 +36,7 @@ import {
   JSONMappable,
 } from '../types'
 import { createProxy } from '../utils/proxy'
+import { SuperglueResponseError } from '../utils/request'
 
 export function preparePageForSave<T extends JSONMappable = JSONMappable>(
   nextPage: GraftResponse<T> | SaveResponse<T>,
@@ -95,12 +97,21 @@ export function preparePageForSave<T extends JSONMappable = JSONMappable>(
   ) as typeof nextPage
 }
 
+/**
+ * Handles a thunk rejection using a discriminated `ErrorResult`
+ * (when it was an HTTP failure carried by `SuperglueResponseError`) or
+ * rethrow for the caller's `.catch` (network, parse, abort, programming
+ * bugs). Either way, the `superglueError` action is dispatched.
+ */
 function handleFetchErr(
   err: Error,
-  fetchArgs: FetchArgs,
+  _fetchArgs: FetchArgs,
   dispatch: Dispatch
-): never {
+): ErrorResult {
   dispatch(superglueError({ message: err.message }))
+  if (err instanceof SuperglueResponseError) {
+    return { hasError: true, response: err.response }
+  }
   console.error(err)
   throw err
 }
@@ -111,11 +122,12 @@ function buildMeta(
   state: SuperglueState,
   rsp: Response,
   fetchArgs: FetchArgs
-): Meta {
+): Result {
   const { assets: prevAssets } = state
   const { assets: nextAssets } = page
 
-  const meta: Meta = {
+  const meta: Result = {
+    hasError: false,
     pageKey,
     page,
     redirected: rsp.redirected,
@@ -295,7 +307,7 @@ to the same page.
             dispatch(copyPage({ from: placeholderKey, to: pageKey }))
           }
         }
-        const visitMeta: VisitMeta = {
+        const visitMeta: VisitResult = {
           ...meta,
           navigationAction: calculateNavAction(
             meta,
@@ -337,7 +349,7 @@ to the same page.
 }
 
 function calculateNavAction(
-  meta: Meta,
+  meta: Result,
   rsp: Response,
   json: PageResponse,
   isGet: boolean,

--- a/superglue/lib/action_creators/web.ts
+++ b/superglue/lib/action_creators/web.ts
@@ -1,0 +1,45 @@
+import { visit, remote } from './requests'
+import {
+  SuperglueStore,
+  VisitProps,
+  RemoteProps,
+  VisitResult,
+  Result,
+  ErrorResult,
+} from '../types'
+
+/**
+ * Web specific wrapper around the `visit` thunk adding asset-refresh when the
+ * response indicates the client bundle is stale.
+ *
+ * Returns a never-settling promise on that branch so the chain terminates with
+ * the browser unload.
+ */
+export function webVisit(
+  store: SuperglueStore,
+  path: string,
+  options?: VisitProps
+): Promise<VisitResult | ErrorResult> {
+  return store.dispatch(visit(path, options)).then((result) => {
+    if (!result.hasError && result.needsRefresh) {
+      window.location.href = result.pageKey
+      return new Promise<VisitResult | ErrorResult>(() => {
+        // Never settles. The browser is unloading; downstream `.then`
+        // handlers are registered but never fire, and everything is
+        // collected when the page is torn down.
+      })
+    }
+    return result
+  })
+}
+
+/**
+ * Web specific wrapper around the `remote` thunk. Just a passthrough.
+ */
+export function webRemote(
+  store: SuperglueStore,
+  path: string,
+  options?: RemoteProps
+): Promise<Result | ErrorResult> {
+  return store.dispatch(remote(path, options))
+}

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -3,6 +3,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { setConfig } from './config'
 import { urlToPageKey, ujsHandlers, argsForHistory } from './utils'
 import { saveAndProcessPage } from './action_creators'
+import { webVisit, webRemote } from './action_creators/web'
 import {
   historyChange,
   setCSRFToken,
@@ -26,6 +27,8 @@ export {
   NavigationContext,
 } from './components/Navigation'
 export { saveAndProcessPage } from './action_creators'
+export { webVisit, webRemote } from './action_creators/web'
+export { SuperglueResponseError } from './utils/request'
 export {
   beforeFetch,
   beforeVisit,
@@ -131,7 +134,21 @@ export function createApp({
     current: null,
   }
 
-  const { visit, remote } = buildVisitAndRemote(navigatorRef, store)
+  const navigateTo: NavigateTo = (pageKey, options) => {
+    if (!navigatorRef.current) {
+      console.warn(
+        '[superglue] navigateTo called before <Provider /> mounted; no-op'
+      )
+      return false
+    }
+    return navigatorRef.current.navigateTo(pageKey, options)
+  }
+
+  const { visit, remote } = buildVisitAndRemote({
+    navigateTo,
+    visit: (path, options) => webVisit(store, path, options),
+    remote: (path, options) => webRemote(store, path, options),
+  })
 
   const resolvedHistory = history || createHistory()
   resolvedHistory.replace(...argsForHistory(path))
@@ -157,9 +174,7 @@ export function createApp({
   function Provider({ children }: ProviderProps) {
     return (
       <ReduxProvider store={store}>
-        <CableContext.Provider
-          value={{ streamActions, cable: cable ?? null }}
-        >
+        <CableContext.Provider value={{ streamActions, cable: cable ?? null }}>
           <NavigationProvider
             ref={navigatorRef}
             visit={visit}

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -367,11 +367,12 @@ export interface RootState<T = JSONMappable> {
 }
 
 /**
- * Meta is passed to the Promise when visit or remote
- * resolves and contains additional information for
- * navigation.
+ * The success branch of a `remote` call. Resolved by the `remote` thunk
+ * and {@link webRemote}; the `hasError: false` literal acts as the
+ * discriminant for narrowing against {@link ErrorResult}.
  */
-export interface Meta {
+export interface Result {
+  hasError: false
   /**
    * The URL of the response converted to a pageKey. Superglue uses this to
    * persist the {@link SaveResponse} to store, when that happens.
@@ -391,9 +392,24 @@ export interface Meta {
   needsRefresh: boolean
 }
 
-export interface VisitMeta extends Meta {
+/**
+ * The success branch of a `visit` call. Extends {@link Result} with the
+ * computed {@link NavigationAction} for browser-history orchestration.
+ */
+export interface VisitResult extends Result {
   /** The {@link NavigationAction}. This can be used for navigation.*/
   navigationAction: NavigationAction
+}
+
+/**
+ * The error branch returned by `visit` and `remote` when the server
+ * responds with a non-2xx status. Non-HTTP failures (network, parse,
+ * abort, programming bugs) propagate as a rejected promise instead.
+ */
+export interface ErrorResult {
+  hasError: true
+  /** The failed HTTP response. */
+  response: Response
 }
 
 // I can do Visit['props'] or better yet Visit['options']
@@ -404,7 +420,7 @@ export interface VisitMeta extends Meta {
  */
 export type VisitCreator = (
   input: string | PageKey,
-  options: VisitProps
+  options?: VisitProps
 ) => VisitMetaThunk
 
 /**
@@ -413,7 +429,7 @@ export type VisitCreator = (
  */
 export type RemoteCreator = (
   input: string | PageKey,
-  options: RemoteProps
+  options?: RemoteProps
 ) => MetaThunk
 
 export type Dispatch = ThunkDispatch<RootState, undefined, Action>
@@ -476,9 +492,14 @@ export type SaveAndProcessPageThunk = ThunkAction<
   Action
 >
 
-export type MetaThunk = ThunkAction<Promise<Meta>, RootState, undefined, Action>
+export type MetaThunk = ThunkAction<
+  Promise<Result | ErrorResult>,
+  RootState,
+  undefined,
+  Action
+>
 export type VisitMetaThunk = ThunkAction<
-  Promise<VisitMeta>,
+  Promise<VisitResult | ErrorResult>,
   RootState,
   undefined,
   Action
@@ -585,25 +606,39 @@ export interface BuildStore {
 }
 
 /**
- * Provide this callback to {@link ApplicationProps} returning a visit and remote
- * function. These functions will be used by Superglue to power its UJS
- * attributes and passed to your page components and {@link NavigationContextProps}.
- * You may customize this functionality to your liking, e.g, adding a progress
- * bar.
+ * Provide this callback to {@link CreateAppArgs}. Receives a context object
+ * containing `visit` and `remote` callables.  Customize this function to add
+ * progress bars, error reporting (Sentry), or app-specific error-page
+ * redirects.
  *
- * @param navigatorRef
- * @param store
+ * Be sure to returns a wrapped `{ visit, remote }` pair that Superglue and UJS
+ * use for navigation.
  *
- * @returns
+ * @returns A wrapped {@link ApplicationVisit} / {@link ApplicationRemote} pair.
  */
 export interface BuildVisitAndRemote {
-  (
-    navigatorRef: React.RefObject<{ navigateTo: NavigateTo } | null>,
-    store: SuperglueStore
-  ): {
+  (context: BuildVisitAndRemoteContext): {
     visit: ApplicationVisit
     remote: ApplicationRemote
   }
+}
+
+/**
+ * The context passed to {@link BuildVisitAndRemote}
+ *
+ * The visit and remote functions in this context will resolve to a VisitResult
+ * or ErrorResult.
+ */
+export interface BuildVisitAndRemoteContext {
+  /** Navigates after a successful visit. Bound to the createApp instance. */
+  navigateTo: NavigateTo
+  /** Pre-bound visit. Returns a discriminated result. */
+  visit: (
+    path: string,
+    options?: VisitProps
+  ) => Promise<VisitResult | ErrorResult>
+  /** Pre-bound remote. Returns a discriminated result. */
+  remote: (path: string, options?: RemoteProps) => Promise<Result | ErrorResult>
 }
 
 /**
@@ -671,4 +706,3 @@ export interface CreateAppResult {
   Outlet: React.ComponentType
   ujs: Handlers
 }
-

--- a/superglue/lib/types/requests.ts
+++ b/superglue/lib/types/requests.ts
@@ -1,6 +1,6 @@
 import {
-  Meta,
-  VisitMeta,
+  Result,
+  VisitResult,
   PageKey,
   SaveResponse,
   GraftResponse,
@@ -27,7 +27,7 @@ export interface Visit {
    * @param input The first argument to Fetch
    * @param options
    */
-  (input: string | PageKey, options: VisitProps): Promise<Meta>
+  (input: string | PageKey, options: VisitProps): Promise<VisitResult>
 }
 
 // todo: placeholders with redirected requests
@@ -44,7 +44,7 @@ export interface VisitProps extends Omit<BaseProps, 'signal'> {
   placeholderKey?: PageKey
   /**
    * When `true` and the request method is a GET, changes the
-   * `suggestionAction` of the Meta object to `none` so that Superglue does
+   * `suggestionAction` of the Result object to `none` so that Superglue does
    * nothing to window.history.
    * When the GET response was redirected, changes `navigationAction` to `replace`
    */
@@ -65,7 +65,7 @@ export interface Remote {
    * @param input The first argument to Fetch
    * @param options The fetch RequestInit with additional options
    */
-  (input: string | PageKey, options: RemoteProps): Promise<Meta>
+  (input: string | PageKey, options: RemoteProps): Promise<Result>
 }
 
 /**
@@ -146,6 +146,10 @@ export interface ApplicationRemote {
    * be passed a dataset as an option. This is because Superglue UJS uses
    * ApplicationRemote and will pass the dataset of the HTML element where UJS is
    * enabled on.
+   *
+   * Returns a `Promise<Result>` — terminal branches (HTTP error redirects,
+   * unexpected exceptions) should return a never-settling promise rather
+   * than `undefined` so the chain reflects "the browser is unloading."
    */
   (
     input: string | PageKey,
@@ -154,7 +158,7 @@ export interface ApplicationRemote {
         [name: string]: string | undefined
       }
     }
-  ): Promise<Meta>
+  ): Promise<Result>
 }
 
 export interface ApplicationVisit {
@@ -168,6 +172,11 @@ export interface ApplicationVisit {
    * be passed a dataset as an option. This is because Superglue UJS uses
    * ApplicationVisit and will pass the dataset of the HTML element where UJS is
    * enabled on.
+   *
+   * Returns a `Promise<VisitResult>` — terminal branches (HTTP error
+   * redirects, unexpected exceptions) should return a never-settling
+   * promise rather than `undefined` so the chain reflects "the browser is
+   * unloading."
    */
   (
     input: string | PageKey,
@@ -176,5 +185,5 @@ export interface ApplicationVisit {
         [name: string]: string | undefined
       }
     }
-  ): Promise<VisitMeta | undefined | void>
+  ): Promise<VisitResult>
 }

--- a/superglue/lib/utils/request.ts
+++ b/superglue/lib/utils/request.ts
@@ -23,7 +23,7 @@ function downloadingFile(xhr: Response): boolean {
   return !!(disposition && disposition.match(/^attachment/) !== null)
 }
 
-class SuperglueResponseError extends Error {
+export class SuperglueResponseError extends Error {
   response: Response
 
   constructor(message: string) {

--- a/superglue/spec/features/navigation.spec.jsx
+++ b/superglue/spec/features/navigation.spec.jsx
@@ -4,7 +4,6 @@ import fetchMock from 'fetch-mock'
 import * as rsp from '../fixtures'
 import React, { useContext, useEffect } from 'react'
 import { createMemoryHistory } from 'history'
-import { visit, remote } from '../../lib/action_creators'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NavigationContext } from '../../lib/index'
@@ -34,10 +33,14 @@ const About = () => {
   return <h1>About Page, {heading}</h1>
 }
 
-const buildVisitAndRemote = (navRef, store) => {
+// The feature tests want to drive navigation manually from inside the test
+// page components, so this stub is a plain passthrough — it does NOT
+// auto-navigate on success. The auto-navigate behavior of a real
+// `application_visit.ts` is exercised in `spec/lib/web.spec.js` instead.
+const buildVisitAndRemote = ({ navigateTo: _navigateTo, visit, remote }) => {
   return {
-    visit: (...args) => store.dispatch(visit(...args)),
-    remote: (...args) => store.dispatch(remote(...args)),
+    visit: (path, options) => visit(path, options),
+    remote: (path, options) => remote(path, options),
   }
 }
 
@@ -142,7 +145,7 @@ describe('navigation', () => {
       const pageState = {
         data: { heading: 'Visit Success Some heading 2' },
         csrfToken: 'token',
-        assets: ['application-123.js', 'application-123.js'],
+        assets: ['123.js', '123.css'],
         componentIdentifier: 'about',
         fragments: [],
         savedAt: expect.any(Number),
@@ -213,7 +216,7 @@ describe('navigation', () => {
       const pageState = {
         data: { heading: 'Visit Success Some heading 2' },
         csrfToken: 'token',
-        assets: ['application-123.js', 'application-123.js'],
+        assets: ['123.js', '123.css'],
         componentIdentifier: 'about',
         fragments: [],
         savedAt: expect.any(Number),
@@ -577,7 +580,7 @@ describe('navigation', () => {
       const pageState = {
         data: { heading: 'Visit Success Some heading 2' },
         csrfToken: 'token',
-        assets: ['application-123.js', 'application-123.js'],
+        assets: ['123.js', '123.css'],
         componentIdentifier: 'about',
         fragments: [],
         savedAt: expect.any(Number),

--- a/superglue/spec/fixtures.js
+++ b/superglue/spec/fixtures.js
@@ -3,7 +3,7 @@ export const visitSuccess = () => {
     body: JSON.stringify({
       data: { heading: 'Visit Success Some heading 2' },
       csrfToken: 'token',
-      assets: ['application-123.js', 'application-123.js'],
+      assets: ['123.js', '123.css'],
       componentIdentifier: 'about',
       fragments: [],
     }),
@@ -21,7 +21,7 @@ export const graftSuccessWithNewZip = (body) => {
       action: 'graft',
       path: 'data.address',
       csrfToken: 'token',
-      assets: ['application-new123.js', 'application-new123.js'],
+      assets: ['123.js', '123.css'],
       fragments: [],
       ...body,
     }),

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -1113,7 +1113,7 @@ describe('action creators', () => {
       })
     })
 
-    it('fires SUPERGLUE_REQUEST_ERROR on a bad server response status', () => {
+    it('resolves with hasError and dispatches SUPERGLUE_ERROR on a bad server response status', () => {
       const store = buildStore(initialState())
       fetchMock.mock('https://example.com/foo?format=json', {
         body: '{}',
@@ -1146,10 +1146,12 @@ describe('action creators', () => {
         },
       ]
 
-      return store.dispatch(remote('/foo')).catch((err) => {
-        expect(err.message).toEqual('Internal Server Error')
-        expect(err.response.status).toEqual(500)
-
+      return store.dispatch(remote('/foo')).then((result) => {
+        expect(result.hasError).toBe(true)
+        if (result.hasError) {
+          expect(result.response.status).toEqual(500)
+          expect(result.response.statusText).toEqual('Internal Server Error')
+        }
         expect(allSuperglueActions(store)).toEqual(
           expect.objectContaining(expectedActions)
         )

--- a/superglue/spec/lib/web.spec.js
+++ b/superglue/spec/lib/web.spec.js
@@ -1,0 +1,196 @@
+import { describe, expect, afterEach, it, vi } from 'vitest'
+import fetchMock from 'fetch-mock'
+import { configureStore } from '@reduxjs/toolkit'
+import { rootReducer } from '../../lib'
+import { webVisit, webRemote } from '../../lib/action_creators/web'
+
+const buildStore = (preloadedState) =>
+  configureStore({
+    preloadedState,
+    reducer: { ...rootReducer },
+  })
+
+const initialState = () => ({
+  superglue: {
+    currentPageKey: '/bar',
+    csrfToken: 'token',
+    assets: [],
+  },
+})
+
+const successBody = () =>
+  JSON.stringify({
+    data: { heading: 'Some heading' },
+    componentIdentifier: 'about',
+    csrfToken: 'token',
+    assets: [],
+    defers: [],
+    fragments: [],
+  })
+
+const staleAssetsBody = () =>
+  JSON.stringify({
+    data: { heading: 'Some heading' },
+    componentIdentifier: 'about',
+    csrfToken: 'token',
+    assets: ['app-NEW.js'],
+    defers: [],
+    fragments: [],
+  })
+
+// jsdom's window.location is non-configurable, so we can't intercept the
+// `href` setter directly. We rely on the structural signal instead: when
+// webVisit decides to redirect, it returns a never-settling promise. Racing
+// against a short timeout lets us assert "the chain was terminated" without
+// touching window.location at all.
+
+afterEach(() => {
+  fetchMock.restore()
+  vi.restoreAllMocks()
+})
+
+describe('webVisit', () => {
+  it('passes through a successful response as a Result with hasError: false', () => {
+    const store = buildStore(initialState())
+    fetchMock.mock('https://example.com/foo?format=json', {
+      body: successBody(),
+      headers: { 'content-type': 'application/json' },
+    })
+
+    return webVisit(store, '/foo').then((result) => {
+      expect(result.hasError).toBe(false)
+      if (!result.hasError) {
+        expect(result.pageKey).toEqual('/foo')
+        expect(result.componentIdentifier).toEqual('about')
+        expect(result.navigationAction).toBeDefined()
+      }
+    })
+  })
+
+  it('returns a never-settling promise when needsRefresh is true', async () => {
+    const store = buildStore({
+      superglue: {
+        currentPageKey: '/bar',
+        csrfToken: 'token',
+        assets: ['app-OLD.js'],
+      },
+    })
+    fetchMock.mock('https://example.com/foo?format=json', {
+      body: staleAssetsBody(),
+      headers: { 'content-type': 'application/json' },
+    })
+
+    const sentinel = Symbol('unsettled')
+    const sleep = (ms) =>
+      new Promise((resolve) => setTimeout(() => resolve(sentinel), ms))
+
+    const winner = await Promise.race([webVisit(store, '/foo'), sleep(50)])
+
+    expect(winner).toBe(sentinel)
+  })
+
+  it('resolves with hasError: true on a 5xx response (no rejection)', () => {
+    const store = buildStore(initialState())
+    fetchMock.mock('https://example.com/foo?format=json', {
+      body: '{}',
+      status: 500,
+    })
+
+    return webVisit(store, '/foo').then((result) => {
+      expect(result.hasError).toBe(true)
+      if (result.hasError) {
+        expect(result.response.status).toEqual(500)
+      }
+    })
+  })
+
+  it('rejects on a JSON parse failure (not converted to ErrorResult)', () => {
+    const store = buildStore(initialState())
+    fetchMock.mock('https://example.com/foo?format=json', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: '',
+    })
+
+    return webVisit(store, '/foo').then(
+      () => {
+        throw new Error('expected promise to reject')
+      },
+      (err) => {
+        expect(err.message).toMatch(/Unexpected end of JSON input/)
+      }
+    )
+  })
+})
+
+describe('webRemote', () => {
+  it('passes through a successful response as a Result', () => {
+    const store = buildStore(initialState())
+    fetchMock.mock('https://example.com/foo?format=json', {
+      body: successBody(),
+      headers: { 'content-type': 'application/json' },
+    })
+
+    return webRemote(store, '/foo').then((result) => {
+      expect(result.hasError).toBe(false)
+      if (!result.hasError) {
+        expect(result.pageKey).toEqual('/foo')
+      }
+    })
+  })
+
+  it('settles even when needsRefresh is true (does not redirect)', async () => {
+    const store = buildStore({
+      superglue: {
+        currentPageKey: '/bar',
+        csrfToken: 'token',
+        assets: ['app-OLD.js'],
+      },
+    })
+    fetchMock.mock('https://example.com/foo?format=json', {
+      body: staleAssetsBody(),
+      headers: { 'content-type': 'application/json' },
+    })
+
+    // No race against a timeout; webRemote should resolve normally even
+    // though the response carries needsRefresh: true.
+    const result = await webRemote(store, '/foo')
+    expect(result.hasError).toBe(false)
+    if (!result.hasError) {
+      expect(result.needsRefresh).toBe(true)
+    }
+  })
+
+  it('resolves with hasError: true on a 5xx response', () => {
+    const store = buildStore(initialState())
+    fetchMock.mock('https://example.com/foo?format=json', {
+      body: '{}',
+      status: 500,
+    })
+
+    return webRemote(store, '/foo').then((result) => {
+      expect(result.hasError).toBe(true)
+      if (result.hasError) {
+        expect(result.response.status).toEqual(500)
+      }
+    })
+  })
+
+  it('rejects on a JSON parse failure', () => {
+    const store = buildStore(initialState())
+    fetchMock.mock('https://example.com/foo?format=json', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body: '',
+    })
+
+    return webRemote(store, '/foo').then(
+      () => {
+        throw new Error('expected promise to reject')
+      },
+      (err) => {
+        expect(err.message).toMatch(/Unexpected end of JSON input/)
+      }
+    )
+  })
+})


### PR DESCRIPTION
This make creating a buildVisitAndRemote easy to create. We take care of the most common scenario (refresh foor assets) and give devs an easier way to implement their own version of `visit` and `remote`.

There are now 2 types of errors. Server errors now flow through the `then` chain along with the success case. Network issues, bugs flow through the `catch`.