### PR TITLE
Better evicition

### DIFF
--- a/superglue/lib/action_creators/index.ts
+++ b/superglue/lib/action_creators/index.ts
@@ -125,6 +125,7 @@ export function saveAndProcessPage(
             saveFragment({
               fragmentId: id,
               data: node,
+              pageKey,
             })
           )
         }

--- a/superglue/lib/action_creators/stream.ts
+++ b/superglue/lib/action_creators/stream.ts
@@ -1,11 +1,7 @@
 import { ThunkAction } from 'redux-thunk'
 import { Action } from '@reduxjs/toolkit'
 import { setIn, getIn } from '../utils'
-import {
-  appendToFragment,
-  prependToFragment,
-  updateFragment,
-} from '../actions'
+import { appendToFragment, prependToFragment, updateFragment } from '../actions'
 import { JSONMappable, RootState, StreamResponse } from '../types'
 import { StreamMessage } from '../hooks/useStreamSource'
 

--- a/superglue/lib/action_creators/stream.ts
+++ b/superglue/lib/action_creators/stream.ts
@@ -1,7 +1,11 @@
 import { ThunkAction } from 'redux-thunk'
 import { Action } from '@reduxjs/toolkit'
 import { setIn, getIn } from '../utils'
-import { appendToFragment, prependToFragment, saveFragment } from '../actions'
+import {
+  appendToFragment,
+  prependToFragment,
+  updateFragment,
+} from '../actions'
 import { JSONMappable, RootState, StreamResponse } from '../types'
 import { StreamMessage } from '../hooks/useStreamSource'
 
@@ -25,7 +29,7 @@ export const streamPrepend = (
     if (options.saveAs) {
       const { saveAs } = options
       dispatch(
-        saveFragment({
+        updateFragment({
           fragmentId: saveAs,
           data,
         })
@@ -67,7 +71,7 @@ export const streamAppend = (
     if (options.saveAs) {
       const { saveAs } = options
       dispatch(
-        saveFragment({
+        updateFragment({
           fragmentId: saveAs,
           data,
         })
@@ -106,7 +110,7 @@ export const streamSave = (
 ): StreamThunk => {
   return (dispatch) => {
     dispatch(
-      saveFragment({
+      updateFragment({
         fragmentId: fragment,
         data,
       })
@@ -126,7 +130,7 @@ export const handleStreamMessage = (rawMessage: string): StreamHandleThunk => {
       nextMessage = setIn(nextMessage, path, { __id: id })
 
       dispatch(
-        saveFragment({
+        updateFragment({
           fragmentId: id,
           data: node,
         })
@@ -173,7 +177,7 @@ export const handleStreamResponse = (
       nextResponse = setIn(nextResponse, path, { __id: id })
 
       dispatch(
-        saveFragment({
+        updateFragment({
           fragmentId: id,
           data: node,
         })

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -234,6 +234,10 @@ export const updateContent = createAction(
   })
 )
 
+export const removeFragments = createAction<{ fragmentIds: string[] }>(
+  '@@superglue/REMOVE_FRAGMENTS'
+)
+
 export const prependToFragment = createAction(
   '@@superglue/PREPEND_TO_FRAGMENT',
   ({ data, fragmentId }: { data: JSONMappable; fragmentId: string }) => {

--- a/superglue/lib/actions.ts
+++ b/superglue/lib/actions.ts
@@ -170,6 +170,27 @@ export const handleFragmentGraft = createAction(
 
 export const saveFragment = createAction(
   '@@superglue/SAVE_FRAGMENT',
+  ({
+    fragmentId,
+    data,
+    pageKey,
+  }: {
+    fragmentId: string
+    data: JSONMappable
+    pageKey: string
+  }) => {
+    return {
+      payload: {
+        fragmentId,
+        data,
+        pageKey,
+      },
+    }
+  }
+)
+
+export const updateFragment = createAction(
+  '@@superglue/UPDATE_FRAGMENT',
   ({ fragmentId, data }: { fragmentId: string; data: JSONMappable }) => {
     return {
       payload: {

--- a/superglue/lib/hooks/useSetFragment.tsx
+++ b/superglue/lib/hooks/useSetFragment.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux'
 import { Immer } from 'immer'
-import { saveFragment } from '../actions'
+import { updateFragment } from '../actions'
 import { RootState, Fragment } from '../types'
 import { Unproxy } from '../types'
 import { FragmentProxy } from './useContent'
@@ -81,7 +81,7 @@ export function useSetFragment() {
     const updatedFragment = immer.produce(currentFragment, updater)
 
     dispatch(
-      saveFragment({
+      updateFragment({
         fragmentId: fragmentId,
         data: updatedFragment,
       })

--- a/superglue/lib/index.tsx
+++ b/superglue/lib/index.tsx
@@ -14,6 +14,7 @@ import {
   resetStore,
 } from './actions'
 import { rootReducer } from './reducers'
+import { pageEvictionMiddleware } from './middleware'
 import { Provider as ReduxProvider } from 'react-redux'
 
 import { CableContext, StreamActions } from './hooks/useStreamSource'
@@ -82,7 +83,7 @@ export const store: SuperglueStore = configureStore({
       serializableCheck: {
         ignoredActions: [beforeFetch.type, beforeVisit.type, beforeRemote.type],
       },
-    }),
+    }).concat(pageEvictionMiddleware),
 })
 
 if (process.env.NODE_ENV !== 'production') {

--- a/superglue/lib/middleware.ts
+++ b/superglue/lib/middleware.ts
@@ -1,0 +1,28 @@
+import type { Middleware } from '@reduxjs/toolkit'
+import { saveResponse, removePage } from './actions'
+import { getConfig } from './config'
+import type { RootState } from './types'
+
+export const pageEvictionMiddleware: Middleware<NonNullable<unknown>, RootState> =
+  (store) => (next) => (action) => {
+    const result = next(action)
+
+    if (saveResponse.match(action)) {
+      const { maxPages } = getConfig()
+      const pages = store.getState().pages
+      const allPageKeys = Object.keys(pages)
+
+      if (allPageKeys.length > maxPages) {
+        const sorted = allPageKeys
+          .map((key) => ({ key, savedAt: pages[key].savedAt }))
+          .sort((a, b) => b.savedAt - a.savedAt)
+
+        const toEvict = sorted.slice(maxPages)
+        for (const { key } of toEvict) {
+          store.dispatch(removePage({ pageKey: key }))
+        }
+      }
+    }
+
+    return result
+  }

--- a/superglue/lib/middleware.ts
+++ b/superglue/lib/middleware.ts
@@ -1,11 +1,41 @@
 import type { Middleware } from '@reduxjs/toolkit'
-import { saveResponse, removePage } from './actions'
+import {
+  saveResponse,
+  removePage,
+  saveFragment,
+  removeFragments,
+  copyPage,
+  resetStore,
+} from './actions'
 import { getConfig } from './config'
 import type { RootState } from './types'
+
+const pageFragments = new Map<string, Set<string>>()
 
 export const pageEvictionMiddleware: Middleware<NonNullable<unknown>, RootState> =
   (store) => (next) => (action) => {
     const result = next(action)
+
+    if (resetStore.match(action)) {
+      pageFragments.clear()
+      return result
+    }
+
+    if (saveFragment.match(action)) {
+      const { pageKey, fragmentId } = action.payload
+      if (!pageFragments.has(pageKey)) {
+        pageFragments.set(pageKey, new Set())
+      }
+      pageFragments.get(pageKey)!.add(fragmentId)
+    }
+
+    if (copyPage.match(action)) {
+      const { from, to } = action.payload
+      const existing = pageFragments.get(from)
+      if (existing) {
+        pageFragments.set(to, new Set(existing))
+      }
+    }
 
     if (saveResponse.match(action)) {
       const { maxPages } = getConfig()
@@ -20,6 +50,29 @@ export const pageEvictionMiddleware: Middleware<NonNullable<unknown>, RootState>
         const toEvict = sorted.slice(maxPages)
         for (const { key } of toEvict) {
           store.dispatch(removePage({ pageKey: key }))
+        }
+      }
+    }
+
+    if (removePage.match(action)) {
+      const { pageKey } = action.payload
+      const evictedFragments = pageFragments.get(pageKey)
+      pageFragments.delete(pageKey)
+
+      if (evictedFragments && evictedFragments.size > 0) {
+        const stillReferenced = new Set<string>()
+        for (const [, fragments] of pageFragments) {
+          for (const id of fragments) {
+            stillReferenced.add(id)
+          }
+        }
+
+        const orphaned = Array.from(evictedFragments).filter(
+          (id) => !stillReferenced.has(id)
+        )
+
+        if (orphaned.length > 0) {
+          store.dispatch(removeFragments({ fragmentIds: orphaned }))
         }
       }
     }

--- a/superglue/lib/middleware.ts
+++ b/superglue/lib/middleware.ts
@@ -12,70 +12,72 @@ import type { RootState } from './types'
 
 const pageFragments = new Map<string, Set<string>>()
 
-export const pageEvictionMiddleware: Middleware<NonNullable<unknown>, RootState> =
-  (store) => (next) => (action) => {
-    const result = next(action)
+export const pageEvictionMiddleware: Middleware<
+  NonNullable<unknown>,
+  RootState
+> = (store) => (next) => (action) => {
+  const result = next(action)
 
-    if (resetStore.match(action)) {
-      pageFragments.clear()
-      return result
-    }
-
-    if (saveFragment.match(action)) {
-      const { pageKey, fragmentId } = action.payload
-      if (!pageFragments.has(pageKey)) {
-        pageFragments.set(pageKey, new Set())
-      }
-      pageFragments.get(pageKey)!.add(fragmentId)
-    }
-
-    if (copyPage.match(action)) {
-      const { from, to } = action.payload
-      const existing = pageFragments.get(from)
-      if (existing) {
-        pageFragments.set(to, new Set(existing))
-      }
-    }
-
-    if (saveResponse.match(action)) {
-      const { maxPages } = getConfig()
-      const pages = store.getState().pages
-      const allPageKeys = Object.keys(pages)
-
-      if (allPageKeys.length > maxPages) {
-        const sorted = allPageKeys
-          .map((key) => ({ key, savedAt: pages[key].savedAt }))
-          .sort((a, b) => b.savedAt - a.savedAt)
-
-        const toEvict = sorted.slice(maxPages)
-        for (const { key } of toEvict) {
-          store.dispatch(removePage({ pageKey: key }))
-        }
-      }
-    }
-
-    if (removePage.match(action)) {
-      const { pageKey } = action.payload
-      const evictedFragments = pageFragments.get(pageKey)
-      pageFragments.delete(pageKey)
-
-      if (evictedFragments && evictedFragments.size > 0) {
-        const stillReferenced = new Set<string>()
-        for (const [, fragments] of pageFragments) {
-          for (const id of fragments) {
-            stillReferenced.add(id)
-          }
-        }
-
-        const orphaned = Array.from(evictedFragments).filter(
-          (id) => !stillReferenced.has(id)
-        )
-
-        if (orphaned.length > 0) {
-          store.dispatch(removeFragments({ fragmentIds: orphaned }))
-        }
-      }
-    }
-
+  if (resetStore.match(action)) {
+    pageFragments.clear()
     return result
   }
+
+  if (saveFragment.match(action)) {
+    const { pageKey, fragmentId } = action.payload
+    if (!pageFragments.has(pageKey)) {
+      pageFragments.set(pageKey, new Set())
+    }
+    pageFragments.get(pageKey)!.add(fragmentId)
+  }
+
+  if (copyPage.match(action)) {
+    const { from, to } = action.payload
+    const existing = pageFragments.get(from)
+    if (existing) {
+      pageFragments.set(to, new Set(existing))
+    }
+  }
+
+  if (saveResponse.match(action)) {
+    const { maxPages } = getConfig()
+    const pages = store.getState().pages
+    const allPageKeys = Object.keys(pages)
+
+    if (allPageKeys.length > maxPages) {
+      const sorted = allPageKeys
+        .map((key) => ({ key, savedAt: pages[key].savedAt }))
+        .sort((a, b) => b.savedAt - a.savedAt)
+
+      const toEvict = sorted.slice(maxPages)
+      for (const { key } of toEvict) {
+        store.dispatch(removePage({ pageKey: key }))
+      }
+    }
+  }
+
+  if (removePage.match(action)) {
+    const { pageKey } = action.payload
+    const evictedFragments = pageFragments.get(pageKey)
+    pageFragments.delete(pageKey)
+
+    if (evictedFragments && evictedFragments.size > 0) {
+      const stillReferenced = new Set<string>()
+      for (const [, fragments] of pageFragments) {
+        for (const id of fragments) {
+          stillReferenced.add(id)
+        }
+      }
+
+      const orphaned = Array.from(evictedFragments).filter(
+        (id) => !stillReferenced.has(id)
+      )
+
+      if (orphaned.length > 0) {
+        store.dispatch(removeFragments({ fragmentIds: orphaned }))
+      }
+    }
+  }
+
+  return result
+}

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -11,6 +11,7 @@ import {
   handleFragmentGraft,
   saveFragment,
   updateFragment,
+  removeFragments,
   appendToFragment,
   prependToFragment,
   updateContent,
@@ -252,6 +253,15 @@ export function fragmentReducer(
 ): AllFragments {
   if (action.type === resetStore.type) {
     return {}
+  }
+
+  if (removeFragments.match(action)) {
+    const { fragmentIds } = action.payload
+    const next = { ...state }
+    for (const id of fragmentIds) {
+      delete next[id]
+    }
+    return next
   }
 
   if (handleFragmentGraft.match(action)) {

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -15,7 +15,6 @@ import {
   updateContent,
   resetStore,
 } from '../actions'
-import { getConfig } from '../config'
 import {
   AllPages,
   Page,
@@ -26,20 +25,6 @@ import {
   JSONMappable,
   AllFragments,
 } from '../types'
-
-function constrainPagesSize(state: AllPages) {
-  const { maxPages } = getConfig()
-  const allPageKeys = Object.keys(state)
-  const cacheTimesRecentFirst = allPageKeys
-    .map((key) => state[key].savedAt)
-    .sort((a, b) => b - a)
-
-  for (const key of Array.from(allPageKeys)) {
-    if (state[key].savedAt <= cacheTimesRecentFirst[maxPages - 1]) {
-      delete state[key]
-    }
-  }
-}
 
 function handleSaveResponse(
   state: AllPages,
@@ -52,7 +37,6 @@ function handleSaveResponse(
     ...page,
     savedAt: Date.now(),
   }
-  constrainPagesSize(state)
   state[pageKey] = nextPage
 
   return state

--- a/superglue/lib/reducers/index.ts
+++ b/superglue/lib/reducers/index.ts
@@ -10,6 +10,7 @@ import {
   removePage,
   handleFragmentGraft,
   saveFragment,
+  updateFragment,
   appendToFragment,
   prependToFragment,
   updateContent,
@@ -259,6 +260,15 @@ export function fragmentReducer(
   }
 
   if (saveFragment.match(action)) {
+    const { fragmentId, data } = action.payload
+
+    return {
+      ...state,
+      [fragmentId]: data,
+    }
+  }
+
+  if (updateFragment.match(action)) {
     const { fragmentId, data } = action.payload
 
     return {

--- a/superglue/spec/lib/action_creators.spec.js
+++ b/superglue/spec/lib/action_creators.spec.js
@@ -290,6 +290,7 @@ describe('action creators', () => {
               greetings: 'existing greeting',
             },
             fragmentId: 'info',
+            pageKey: '/bar',
           },
           type: '@@superglue/SAVE_FRAGMENT',
         },

--- a/superglue/spec/lib/middleware.spec.js
+++ b/superglue/spec/lib/middleware.spec.js
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { configureStore } from '@reduxjs/toolkit'
 import { rootReducer } from '../../lib/reducers'
 import { pageEvictionMiddleware } from '../../lib/middleware'
+import { setConfig } from '../../lib/config'
 
 const buildStore = (preloadedState) => {
   return configureStore({
@@ -12,46 +13,277 @@ const buildStore = (preloadedState) => {
   })
 }
 
+const defaultSuperglue = {
+  currentPageKey: '/',
+  search: {},
+  assets: [],
+}
+
 describe('pageEvictionMiddleware', () => {
-  it('saves a maximum of 20 pages', () => {
-    const pages = {}
+  let now
 
-    for (var i = 0; i < 20; i++) {
-      pages[`/foo${i}`] = {
-        data: {},
-        csrfToken: 'token',
-        assets: ['application-123.js'],
-        pageKey: '/foo',
-        fragments: [],
-        savedAt: i,
-      }
-    }
+  beforeEach(() => {
+    now = 1000
+    vi.spyOn(Date, 'now').mockImplementation(() => now++)
+  })
 
-    const store = buildStore({
-      pages,
-      fragments: {},
-      superglue: {
-        currentPageKey: '/foo0',
-        search: {},
-        assets: [],
-      },
-    })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    setConfig({ maxPages: 20 })
+  })
 
-    store.dispatch({
-      type: '@@superglue/SAVE_RESPONSE',
-      payload: {
-        pageKey: '/foo21',
-        page: {
+  describe('page eviction', () => {
+    it('saves a maximum of 20 pages', () => {
+      const pages = {}
+
+      for (var i = 0; i < 20; i++) {
+        pages[`/foo${i}`] = {
           data: {},
           csrfToken: 'token',
           assets: ['application-123.js'],
+          pageKey: '/foo',
+          fragments: [],
+          savedAt: i,
+        }
+      }
+
+      const store = buildStore({
+        pages,
+        fragments: {},
+        superglue: defaultSuperglue,
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/foo21',
+          page: {
+            data: {},
+            csrfToken: 'token',
+            assets: ['application-123.js'],
+          },
         },
-      },
+      })
+
+      const nextState = store.getState().pages
+      expect(Object.keys(nextState).length).toEqual(20)
+      expect(nextState.hasOwnProperty('/foo21')).toEqual(true)
+      expect(nextState.hasOwnProperty('/foo0')).toEqual(false)
+    })
+  })
+
+  describe('fragment cleanup', () => {
+    it('removes orphaned fragments when a page is evicted', () => {
+      setConfig({ maxPages: 2 })
+
+      const store = buildStore({
+        pages: {},
+        fragments: {},
+        superglue: defaultSuperglue,
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'fragment_a', data: { a: 1 }, pageKey: '/a' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/a',
+          page: { data: { ref: { __id: 'fragment_a' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'fragment_b', data: { b: 1 }, pageKey: '/b' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/b',
+          page: { data: { ref: { __id: 'fragment_b' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      expect(store.getState().fragments).toHaveProperty('fragment_a')
+      expect(store.getState().fragments).toHaveProperty('fragment_b')
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'fragment_c', data: { c: 1 }, pageKey: '/c' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/c',
+          page: { data: { ref: { __id: 'fragment_c' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      expect(store.getState().fragments).not.toHaveProperty('fragment_a')
+      expect(store.getState().fragments).toHaveProperty('fragment_b')
+      expect(store.getState().fragments).toHaveProperty('fragment_c')
     })
 
-    const nextState = store.getState().pages
-    expect(Object.keys(nextState).length).toEqual(20)
-    expect(nextState.hasOwnProperty('/foo21')).toEqual(true)
-    expect(nextState.hasOwnProperty('/foo0')).toEqual(false)
+    it('keeps fragments shared across pages', () => {
+      setConfig({ maxPages: 2 })
+
+      const store = buildStore({
+        pages: {},
+        fragments: {},
+        superglue: defaultSuperglue,
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'fragment_shared', data: { shared: 1 }, pageKey: '/a' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/a',
+          page: { data: { ref: { __id: 'fragment_shared' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'fragment_shared', data: { shared: 1 }, pageKey: '/b' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/b',
+          page: { data: { ref: { __id: 'fragment_shared' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'fragment_c', data: { c: 1 }, pageKey: '/c' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/c',
+          page: { data: { ref: { __id: 'fragment_c' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      expect(store.getState().fragments).toHaveProperty('fragment_shared')
+      expect(store.getState().fragments).toHaveProperty('fragment_c')
+    })
+
+    it('removes fragments on explicit removePage', () => {
+      const store = buildStore({
+        pages: {},
+        fragments: {},
+        superglue: defaultSuperglue,
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'frag_1', data: { x: 1 }, pageKey: '/page' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/page',
+          page: { data: { ref: { __id: 'frag_1' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      expect(store.getState().fragments).toHaveProperty('frag_1')
+
+      store.dispatch({
+        type: '@@superglue/REMOVE_PAGE',
+        payload: { pageKey: '/page' },
+      })
+
+      expect(store.getState().fragments).not.toHaveProperty('frag_1')
+    })
+
+    it('copies fragment associations on copyPage', () => {
+      const store = buildStore({
+        pages: {},
+        fragments: {},
+        superglue: defaultSuperglue,
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'frag_1', data: { x: 1 }, pageKey: '/original' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/original',
+          page: { data: { ref: { __id: 'frag_1' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      store.dispatch({
+        type: '@@superglue/COPY_PAGE',
+        payload: { from: '/original', to: '/copy' },
+      })
+
+      store.dispatch({
+        type: '@@superglue/REMOVE_PAGE',
+        payload: { pageKey: '/original' },
+      })
+
+      expect(store.getState().fragments).toHaveProperty('frag_1')
+
+      store.dispatch({
+        type: '@@superglue/REMOVE_PAGE',
+        payload: { pageKey: '/copy' },
+      })
+
+      expect(store.getState().fragments).not.toHaveProperty('frag_1')
+    })
+
+    it('clears pageFragments on resetStore', () => {
+      const store = buildStore({
+        pages: {},
+        fragments: {},
+        superglue: defaultSuperglue,
+      })
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'frag_1', data: { x: 1 }, pageKey: '/page' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/page',
+          page: { data: { ref: { __id: 'frag_1' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      store.dispatch({ type: '@@superglue/RESET' })
+
+      expect(store.getState().fragments).toEqual({})
+
+      store.dispatch({
+        type: '@@superglue/SAVE_FRAGMENT',
+        payload: { fragmentId: 'frag_2', data: { y: 1 }, pageKey: '/new' },
+      })
+      store.dispatch({
+        type: '@@superglue/SAVE_RESPONSE',
+        payload: {
+          pageKey: '/new',
+          page: { data: { ref: { __id: 'frag_2' } }, csrfToken: 't', assets: [] },
+        },
+      })
+
+      store.dispatch({
+        type: '@@superglue/REMOVE_PAGE',
+        payload: { pageKey: '/new' },
+      })
+
+      expect(store.getState().fragments).not.toHaveProperty('frag_2')
+    })
   })
 })

--- a/superglue/spec/lib/middleware.spec.js
+++ b/superglue/spec/lib/middleware.spec.js
@@ -90,7 +90,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/a',
-          page: { data: { ref: { __id: 'fragment_a' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'fragment_a' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -102,7 +106,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/b',
-          page: { data: { ref: { __id: 'fragment_b' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'fragment_b' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -117,7 +125,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/c',
-          page: { data: { ref: { __id: 'fragment_c' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'fragment_c' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -137,25 +149,41 @@ describe('pageEvictionMiddleware', () => {
 
       store.dispatch({
         type: '@@superglue/SAVE_FRAGMENT',
-        payload: { fragmentId: 'fragment_shared', data: { shared: 1 }, pageKey: '/a' },
+        payload: {
+          fragmentId: 'fragment_shared',
+          data: { shared: 1 },
+          pageKey: '/a',
+        },
       })
       store.dispatch({
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/a',
-          page: { data: { ref: { __id: 'fragment_shared' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'fragment_shared' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
       store.dispatch({
         type: '@@superglue/SAVE_FRAGMENT',
-        payload: { fragmentId: 'fragment_shared', data: { shared: 1 }, pageKey: '/b' },
+        payload: {
+          fragmentId: 'fragment_shared',
+          data: { shared: 1 },
+          pageKey: '/b',
+        },
       })
       store.dispatch({
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/b',
-          page: { data: { ref: { __id: 'fragment_shared' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'fragment_shared' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -167,7 +195,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/c',
-          page: { data: { ref: { __id: 'fragment_c' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'fragment_c' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -190,7 +222,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/page',
-          page: { data: { ref: { __id: 'frag_1' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'frag_1' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -219,7 +255,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/original',
-          page: { data: { ref: { __id: 'frag_1' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'frag_1' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -258,7 +298,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/page',
-          page: { data: { ref: { __id: 'frag_1' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'frag_1' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 
@@ -274,7 +318,11 @@ describe('pageEvictionMiddleware', () => {
         type: '@@superglue/SAVE_RESPONSE',
         payload: {
           pageKey: '/new',
-          page: { data: { ref: { __id: 'frag_2' } }, csrfToken: 't', assets: [] },
+          page: {
+            data: { ref: { __id: 'frag_2' } },
+            csrfToken: 't',
+            assets: [],
+          },
         },
       })
 

--- a/superglue/spec/lib/middleware.spec.js
+++ b/superglue/spec/lib/middleware.spec.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { configureStore } from '@reduxjs/toolkit'
+import { rootReducer } from '../../lib/reducers'
+import { pageEvictionMiddleware } from '../../lib/middleware'
+
+const buildStore = (preloadedState) => {
+  return configureStore({
+    preloadedState,
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(pageEvictionMiddleware),
+  })
+}
+
+describe('pageEvictionMiddleware', () => {
+  it('saves a maximum of 20 pages', () => {
+    const pages = {}
+
+    for (var i = 0; i < 20; i++) {
+      pages[`/foo${i}`] = {
+        data: {},
+        csrfToken: 'token',
+        assets: ['application-123.js'],
+        pageKey: '/foo',
+        fragments: [],
+        savedAt: i,
+      }
+    }
+
+    const store = buildStore({
+      pages,
+      fragments: {},
+      superglue: {
+        currentPageKey: '/foo0',
+        search: {},
+        assets: [],
+      },
+    })
+
+    store.dispatch({
+      type: '@@superglue/SAVE_RESPONSE',
+      payload: {
+        pageKey: '/foo21',
+        page: {
+          data: {},
+          csrfToken: 'token',
+          assets: ['application-123.js'],
+        },
+      },
+    })
+
+    const nextState = store.getState().pages
+    expect(Object.keys(nextState).length).toEqual(20)
+    expect(nextState.hasOwnProperty('/foo21')).toEqual(true)
+    expect(nextState.hasOwnProperty('/foo0')).toEqual(false)
+  })
+})

--- a/superglue/spec/lib/reducers.spec.js
+++ b/superglue/spec/lib/reducers.spec.js
@@ -383,37 +383,6 @@ describe('reducers', () => {
         )
       })
 
-      it('saves a maximum of 20 pages', () => {
-        const prevState = {}
-
-        for (var i = 0; i < 20; i++) {
-          prevState[`/foo${i}`] = {
-            data: {},
-            csrfToken: 'token',
-            assets: ['application-123.js'],
-            pageKey: '/foo',
-            fragments: [],
-            savedAt: i,
-          }
-        }
-
-        const nextState = pageReducer(prevState, {
-          type: '@@superglue/SAVE_RESPONSE',
-          payload: {
-            pageKey: '/foo21',
-            page: {
-              data: {},
-              csrfToken: 'token',
-              assets: ['application-123.js'],
-            },
-          },
-        })
-
-        expect(Object.keys(nextState).length).toEqual(20)
-        expect(nextState.hasOwnProperty('/foo21')).toEqual(true)
-        expect(nextState.hasOwnProperty('/foo0')).toEqual(false)
-      })
-
       it('does nothing when there are no prev fragments to use as placeholder', () => {
         const prevState = {
           '/bar': {

--- a/superglue/spec/lib/useSetFragment.spec.jsx
+++ b/superglue/spec/lib/useSetFragment.spec.jsx
@@ -425,7 +425,7 @@ describe('useSetFragment', () => {
       })
 
       expect(dispatchSpy).toHaveBeenCalledWith({
-        type: '@@superglue/SAVE_FRAGMENT',
+        type: '@@superglue/UPDATE_FRAGMENT',
         payload: {
           fragmentId: 'user_123',
           data: {


### PR DESCRIPTION
This adds a better eviction process for the LRU cache. Previously fragments were being orphaned, but this allows for tracking which fragment was created for which page using a set. Then when its time to evict, we use all the sets to figure out which fragments to remove. 