### PR TITLE
Add copy to

### DIFF
--- a/superglue/lib/components/Navigation.tsx
+++ b/superglue/lib/components/Navigation.tsx
@@ -7,11 +7,12 @@ import React, {
   ForwardedRef,
 } from 'react'
 import { urlToPageKey } from '../utils'
-import { removePage, setActivePage } from '../actions'
+import { removePage, setActivePage, copyPage } from '../actions'
 import {
   HistoryState,
   RootState,
   NavigateTo,
+  CopyTo,
   NavigationContextProps,
   NavigationProviderProps,
   NavigationOutletProps,
@@ -155,6 +156,16 @@ const NavigationProvider = forwardRef(function NavigationProvider(
     }
   }
 
+  const copyTo: CopyTo = (path) => {
+    const nextPageKey = urlToPageKey(path)
+
+    if (nextPageKey === currentPageKey) {
+      return
+    }
+
+    store.dispatch(copyPage({ from: currentPageKey, to: path }))
+  }
+
   const navigateTo: NavigateTo = (
     path,
     { action } = {
@@ -227,7 +238,14 @@ const NavigationProvider = forwardRef(function NavigationProvider(
 
   return (
     <NavigationContext.Provider
-      value={{ pageKey: currentPageKey, search, navigateTo, visit, remote }}
+      value={{
+        pageKey: currentPageKey,
+        search,
+        navigateTo,
+        copyTo,
+        visit,
+        remote,
+      }}
     >
       {children}
     </NavigationContext.Provider>

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -562,8 +562,11 @@ export type NavigateTo = (
  * @prop search The current pageKey (current url) query params as an object.
  * @interface
  */
+export type CopyTo = (path: Keypath) => void
+
 export type NavigationContextProps = {
   navigateTo: NavigateTo
+  copyTo: CopyTo
   visit: ApplicationVisit
   remote: ApplicationRemote
   pageKey: SuperglueState['currentPageKey']

--- a/superglue/spec/lib/NavComponent.spec.jsx
+++ b/superglue/spec/lib/NavComponent.spec.jsx
@@ -308,6 +308,126 @@ describe('Nav', () => {
       })
     })
 
+    it('copyTo dispatches copyPage with correct from/to', async () => {
+      const history = createMemoryHistory({})
+      history.push('/home', {
+        superglue: true,
+        pageKey: '/home',
+        posX: 0,
+        posY: 0,
+      })
+
+      const store = buildStore({
+        pages: {
+          '/home': {
+            componentIdentifier: 'home',
+            data: { greeting: 'hello' },
+            fragments: [],
+            restoreStrategy: 'fromCacheOnly',
+          },
+        },
+        superglue: {
+          csrfToken: 'abc',
+          currentPageKey: '/home',
+        },
+      })
+
+      const HomeWithCopy = () => {
+        const { copyTo } = useContext(NavigationContext)
+        const copy = () => {
+          copyTo('/copied')
+        }
+
+        return (
+          <div>
+            <h1>Home Page</h1>
+            <button onClick={copy}>copy</button>
+          </div>
+        )
+      }
+
+      render(
+        <Provider store={store}>
+          <NavigationProvider history={history}>
+            <NavigationOutlet mapping={{ home: HomeWithCopy }} />
+          </NavigationProvider>
+        </Provider>
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByText('copy'))
+
+      const actions = allSuperglueActions(store)
+      const copyAction = actions.find((a) => a.type === '@@superglue/COPY_PAGE')
+
+      expect(copyAction).toEqual({
+        type: '@@superglue/COPY_PAGE',
+        payload: { from: '/home', to: '/copied' },
+      })
+
+      expect(store.getState().pages['/home'].data).toEqual({
+        greeting: 'hello',
+      })
+      expect(store.getState().pages['/copied'].data).toEqual({
+        greeting: 'hello',
+      })
+    })
+
+    it('copyTo is a no-op when copying onto the current page', async () => {
+      const history = createMemoryHistory({})
+      history.push('/home', {
+        superglue: true,
+        pageKey: '/home',
+        posX: 0,
+        posY: 0,
+      })
+
+      const store = buildStore({
+        pages: {
+          '/home': {
+            componentIdentifier: 'home',
+            data: {},
+            fragments: [],
+            restoreStrategy: 'fromCacheOnly',
+          },
+        },
+        superglue: {
+          csrfToken: 'abc',
+          currentPageKey: '/home',
+        },
+      })
+
+      const HomeWithSelfCopy = () => {
+        const { copyTo } = useContext(NavigationContext)
+        const copy = () => {
+          copyTo('/home')
+        }
+
+        return (
+          <div>
+            <h1>Home Page</h1>
+            <button onClick={copy}>copy</button>
+          </div>
+        )
+      }
+
+      render(
+        <Provider store={store}>
+          <NavigationProvider history={history}>
+            <NavigationOutlet mapping={{ home: HomeWithSelfCopy }} />
+          </NavigationProvider>
+        </Provider>
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByText('copy'))
+
+      const actions = allSuperglueActions(store)
+      expect(
+        actions.find((a) => a.type === '@@superglue/COPY_PAGE')
+      ).toBeUndefined()
+    })
+
     it('returns false when action is none', () => {
       const history = createMemoryHistory({})
       const store = buildStore({


### PR DESCRIPTION
This adds a `copyTo` helper that allows devs to copy the currentPage into a page state elsewhere. Its useful when combined with `navigateTo` which requires a page to exist first.