### PR TITLE
Add navigateTo option

### DIFF
--- a/superglue/lib/components/Navigation.tsx
+++ b/superglue/lib/components/Navigation.tsx
@@ -7,7 +7,11 @@ import React, {
   ForwardedRef,
 } from 'react'
 import { urlToPageKey } from '../utils'
-import { removePage, setActivePage, copyPage } from '../actions'
+import { removePage, setActivePage, copyPage, updateContent } from '../actions'
+import { Immer } from 'immer'
+
+const immer = new Immer()
+immer.setAutoFreeze(false)
 import {
   HistoryState,
   RootState,
@@ -168,7 +172,7 @@ const NavigationProvider = forwardRef(function NavigationProvider(
 
   const navigateTo: NavigateTo = (
     path,
-    { action } = {
+    { action, updateContent: updater } = {
       action: 'push',
     }
   ) => {
@@ -183,6 +187,12 @@ const NavigationProvider = forwardRef(function NavigationProvider(
     )
 
     if (hasPage) {
+      if (updater) {
+        const currentData = store.getState().pages[nextPageKey].data
+        const updatedData = immer.produce(currentData, updater)
+        dispatch(updateContent({ pageKey: nextPageKey, data: updatedData }))
+      }
+
       const location = history.location
       const state = location.state as HistoryState
       const historyArgs = [

--- a/superglue/lib/types/index.ts
+++ b/superglue/lib/types/index.ts
@@ -545,8 +545,9 @@ export interface BasicRequestInit extends RequestInit {
  */
 export type NavigateTo = (
   path: Keypath,
-  options: {
-    action: NavigationAction
+  options?: {
+    action?: NavigationAction
+    updateContent?: (draft: JSONMappable) => void
   }
 ) => boolean
 

--- a/superglue/spec/lib/NavComponent.spec.jsx
+++ b/superglue/spec/lib/NavComponent.spec.jsx
@@ -428,6 +428,185 @@ describe('Nav', () => {
       ).toBeUndefined()
     })
 
+    it('navigateTo with updateContent mutates page data before navigating', async () => {
+      const history = createMemoryHistory({})
+      history.push('/home', {
+        superglue: true,
+        pageKey: '/home',
+        posX: 0,
+        posY: 0,
+      })
+
+      const store = buildStore({
+        pages: {
+          '/home': {
+            componentIdentifier: 'home',
+            data: { greeting: 'hello' },
+            fragments: [],
+            restoreStrategy: 'fromCacheOnly',
+          },
+          '/about': {
+            componentIdentifier: 'about',
+            data: { greeting: 'world' },
+            fragments: [],
+            restoreStrategy: 'fromCacheOnly',
+          },
+        },
+        superglue: {
+          csrfToken: 'abc',
+          currentPageKey: '/home',
+        },
+      })
+
+      const HomeWithUpdate = () => {
+        const { navigateTo } = useContext(NavigationContext)
+        const nav = () => {
+          navigateTo('/about', {
+            action: 'push',
+            updateContent: (draft) => {
+              draft.greeting = 'updated'
+            },
+          })
+        }
+
+        return (
+          <div>
+            <h1>Home Page</h1>
+            <button onClick={nav}>navigate</button>
+          </div>
+        )
+      }
+
+      render(
+        <Provider store={store}>
+          <NavigationProvider history={history}>
+            <NavigationOutlet
+              mapping={{ home: HomeWithUpdate, about: About }}
+            />
+          </NavigationProvider>
+        </Provider>
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByText('navigate'))
+
+      expect(store.getState().pages['/about'].data).toEqual({
+        greeting: 'updated',
+      })
+    })
+
+    it('navigateTo with updateContent works with action replace on current page', async () => {
+      const history = createMemoryHistory({})
+      history.push('/home', {
+        superglue: true,
+        pageKey: '/home',
+        posX: 0,
+        posY: 0,
+      })
+
+      const store = buildStore({
+        pages: {
+          '/home': {
+            componentIdentifier: 'home',
+            data: { showModal: false },
+            fragments: [],
+            restoreStrategy: 'fromCacheOnly',
+          },
+        },
+        superglue: {
+          csrfToken: 'abc',
+          currentPageKey: '/home',
+        },
+      })
+
+      const HomeWithReplace = () => {
+        const { navigateTo } = useContext(NavigationContext)
+        const nav = () => {
+          navigateTo('/home', {
+            action: 'replace',
+            updateContent: (draft) => {
+              draft.showModal = true
+            },
+          })
+        }
+
+        return (
+          <div>
+            <h1>Home Page</h1>
+            <button onClick={nav}>replace</button>
+          </div>
+        )
+      }
+
+      render(
+        <Provider store={store}>
+          <NavigationProvider history={history}>
+            <NavigationOutlet mapping={{ home: HomeWithReplace }} />
+          </NavigationProvider>
+        </Provider>
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByText('replace'))
+
+      expect(store.getState().pages['/home'].data).toEqual({
+        showModal: true,
+      })
+    })
+
+    it('navigateTo without updateContent preserves existing behavior', async () => {
+      const history = createMemoryHistory({})
+      history.push('/home', {
+        superglue: true,
+        pageKey: '/home',
+        posX: 0,
+        posY: 0,
+      })
+
+      const store = buildStore({
+        pages: {
+          '/home': {
+            componentIdentifier: 'home',
+            data: { greeting: 'hello' },
+            fragments: [],
+            restoreStrategy: 'fromCacheOnly',
+          },
+        },
+        superglue: {
+          csrfToken: 'abc',
+          currentPageKey: '/home',
+        },
+      })
+
+      let result
+      const HomeWithNav = () => {
+        const { navigateTo } = useContext(NavigationContext)
+        const nav = () => {
+          result = navigateTo('/missing', { action: 'push' })
+        }
+
+        return (
+          <div>
+            <h1>Home Page</h1>
+            <button onClick={nav}>navigate</button>
+          </div>
+        )
+      }
+
+      render(
+        <Provider store={store}>
+          <NavigationProvider history={history}>
+            <NavigationOutlet mapping={{ home: HomeWithNav }} />
+          </NavigationProvider>
+        </Provider>
+      )
+
+      const user = userEvent.setup()
+      await user.click(screen.getByText('navigate'))
+
+      expect(result).toEqual(false)
+    })
+
     it('returns false when action is none', () => {
       const history = createMemoryHistory({})
       const store = buildStore({


### PR DESCRIPTION
This adds the ability to optimistically update using the `navigateTo` helpers. Previously you'd need to fire redux actions to make this happen, but this simplifies things by including an updater to `navigateTo`. Note that the page must exist before you navigate. 

```
  // Copy + navigate with mutation
  copyTo('/posts?showModal=true')
  navigateTo('/posts?showModal=true', {
    action: 'push',
    updateContent: (draft) => { draft.showModal = true }
  })

  // Replace current page with mutation (no copy needed)
  navigateTo('/posts', {
    action: 'replace',
    updateContent: (draft) => { draft.showModal = true }
  })
```