### PR TITLE
Add support for typia

### DIFF
--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+          cache-dependency-path: plugins/typia/go/go.sum
       - name: Setup project
         working-directory: .
         run: npm install

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
       - name: Setup project
         working-directory: .
         run: npm install

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,5 @@ tsup.config.ts
 tsconfig.json
 typedoc.json
 mkdocs.yml
+plugins/typia/go/go.work
+plugins/typia/go/go.work.sum

--- a/lib/hooks/useContent.tsx
+++ b/lib/hooks/useContent.tsx
@@ -111,7 +111,10 @@ export function useContent<T = JSONMappable>(
         new WeakMap()
       ) as T
 
-      options.validate(proxyForValidation)
+      const result = options.validate(proxyForValidation)
+      if (!result.success) {
+        console.error('[Superglue] Content validation failed:', result.errors)
+      }
     }
 
     return proxy

--- a/lib/hooks/useFragment.tsx
+++ b/lib/hooks/useFragment.tsx
@@ -110,7 +110,10 @@ export function useFragment<T, P extends boolean>(
         new WeakMap()
       ) as T
 
-      options.validate(proxyForValidation)
+      const result = options.validate(proxyForValidation)
+      if (!result.success) {
+        console.error('[Superglue] Content validation failed:', result.errors)
+      }
     }
 
     return proxy

--- a/lib/types/page.ts
+++ b/lib/types/page.ts
@@ -1,14 +1,12 @@
 import { JSONMappable, JSONValue } from './json'
 
-/**
- * Options for runtime type validation in `useContent` and `useFragment`.
- * The `validate` callback is typically injected at build time by a
- * Superglue unplugin, but can also be passed manually with any
- * validation library. The callback should report errors via
- * `console.error` or by throwing.
- */
+export type ValidationResult = {
+  success: boolean
+  errors: unknown[]
+}
+
 export type ValidateOption = {
-  validate?: (data: unknown) => void
+  validate?: (data: unknown) => ValidationResult
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
       "types": "./dist/deepkit.d.ts",
       "import": "./dist/deepkit.mjs",
       "require": "./dist/deepkit.cjs"
+    },
+    "./typia": {
+      "ttsc": "./dist/typia.mjs",
+      "types": "./dist/typia.d.ts",
+      "import": "./dist/typia.mjs",
+      "require": "./dist/typia.cjs"
     }
   },
   "license": "MIT",
@@ -52,6 +58,7 @@
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.5.2",
+    "@ttsc/unplugin": "^0.19.2",
     "@types/node": "^22.10.1",
     "@types/rails__actioncable": "^6.1.11",
     "@types/react": "^19.1.8",
@@ -77,10 +84,12 @@
     "redux-thunk": "^3.1.0",
     "rollup": "4.52.5",
     "tsup": "^8.1.0",
+    "ttsc": "^0.19.2",
     "typedoc": "^0.28.10",
     "typedoc-plugin-markdown": "^4.8.1",
     "typedoc-plugin-missing-exports": "~4.1.0",
     "typescript": "^5.5.3",
+    "typia": "^13.1.0",
     "unplugin": "^3.0.0",
     "vitest": "^2.0.2"
   },
@@ -89,7 +98,10 @@
     "@deepkit/type": "^1.0.19",
     "@deepkit/type-compiler": "^1.0.19",
     "@rails/actioncable": "^7 || ^8",
-    "react": "^18 || ^19"
+    "@ttsc/unplugin": ">=0.19.2",
+    "react": "^18 || ^19",
+    "ttsc": ">=0.19.2",
+    "typia": ">=13.1.0"
   },
   "peerDependenciesMeta": {
     "@anycable/web": {
@@ -103,6 +115,20 @@
     },
     "@rails/actioncable": {
       "optional": true
+    },
+    "@ttsc/unplugin": {
+      "optional": true
+    },
+    "ttsc": {
+      "optional": true
+    },
+    "typia": {
+      "optional": true
+    }
+  },
+  "ttsc": {
+    "plugin": {
+      "transform": "@thoughtbot/superglue/typia"
     }
   },
   "dependencies": {

--- a/plugins/deepkit/deepkit.ts
+++ b/plugins/deepkit/deepkit.ts
@@ -7,15 +7,16 @@ const VALIDATE_FN = '__supergluePropsValidator'
 const VALIDATE_HELPER = `
 import { resolveReceiveType as __sgResolveReceiveType, validate as __sgDkValidate } from '@deepkit/type';
 type ReceiveType<T> = unknown;
-function ${VALIDATE_FN}<T>(__type?: ReceiveType<T>): (data: unknown) => void {
+function ${VALIDATE_FN}<T>(__type?: ReceiveType<T>): (data: unknown) => { success: boolean; errors: { path: string; message: string }[] } {
   return function(data: unknown) {
     var resolved = __sgResolveReceiveType(__type);
     var errors = __sgDkValidate(data, resolved);
-    if (errors.length > 0) {
-      console.error('[Superglue] Content validation failed:', errors.map(function(e: any) {
-        return { path: e.path, message: e.message, code: String(e.code) };
-      }));
-    }
+    return {
+      success: errors.length === 0,
+      errors: errors.map(function(e: any) {
+        return { path: e.path, message: e.message };
+      })
+    };
   };
 }
 `

--- a/plugins/deepkit/unplugin-transform.ts
+++ b/plugins/deepkit/unplugin-transform.ts
@@ -9,7 +9,9 @@ import ts from 'typescript'
  * transformations were applied, so callers know whether to prepend their
  * validate helper.
  */
-export function createHookTransformer(validateFnName: string): {
+export function createHookTransformer(
+  validateFnName: string
+): {
   factory: ts.TransformerFactory<ts.SourceFile>
   transformed: () => boolean
 } {
@@ -41,17 +43,19 @@ export function createHookTransformer(validateFnName: string): {
             )
 
             const optionsArg = ts.factory.createObjectLiteralExpression([
-              ts.factory.createPropertyAssignment('validate', validateCall),
+              ts.factory.createPropertyAssignment(
+                'validate',
+                validateCall
+              ),
             ])
 
-            const args = [
-              ...node.arguments.map(
-                (a) => ts.visitNode(a, visit) as ts.Expression
-              ),
-            ]
+            const args = [...node.arguments.map((a) => ts.visitNode(a, visit) as ts.Expression)]
 
             if (isUseContent && node.arguments.length === 0) {
-              args.push(ts.factory.createIdentifier('undefined'), optionsArg)
+              args.push(
+                ts.factory.createIdentifier('undefined'),
+                optionsArg
+              )
             } else {
               args.push(optionsArg)
             }
@@ -85,7 +89,9 @@ export function transformHooks(
   validateFnName: string,
   validateHelper: string
 ): string {
-  const scriptKind = /\.[jt]sx$/.test(id) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  const scriptKind = /\.[jt]sx$/.test(id)
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS
   const sourceFile = ts.createSourceFile(
     id,
     code,

--- a/plugins/deepkit/unplugin-transform.ts
+++ b/plugins/deepkit/unplugin-transform.ts
@@ -9,9 +9,7 @@ import ts from 'typescript'
  * transformations were applied, so callers know whether to prepend their
  * validate helper.
  */
-export function createHookTransformer(
-  validateFnName: string
-): {
+export function createHookTransformer(validateFnName: string): {
   factory: ts.TransformerFactory<ts.SourceFile>
   transformed: () => boolean
 } {
@@ -43,19 +41,17 @@ export function createHookTransformer(
             )
 
             const optionsArg = ts.factory.createObjectLiteralExpression([
-              ts.factory.createPropertyAssignment(
-                'validate',
-                validateCall
-              ),
+              ts.factory.createPropertyAssignment('validate', validateCall),
             ])
 
-            const args = [...node.arguments.map((a) => ts.visitNode(a, visit) as ts.Expression)]
+            const args = [
+              ...node.arguments.map(
+                (a) => ts.visitNode(a, visit) as ts.Expression
+              ),
+            ]
 
             if (isUseContent && node.arguments.length === 0) {
-              args.push(
-                ts.factory.createIdentifier('undefined'),
-                optionsArg
-              )
+              args.push(ts.factory.createIdentifier('undefined'), optionsArg)
             } else {
               args.push(optionsArg)
             }
@@ -89,9 +85,7 @@ export function transformHooks(
   validateFnName: string,
   validateHelper: string
 ): string {
-  const scriptKind = /\.[jt]sx$/.test(id)
-    ? ts.ScriptKind.TSX
-    : ts.ScriptKind.TS
+  const scriptKind = /\.[jt]sx$/.test(id) ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   const sourceFile = ts.createSourceFile(
     id,
     code,

--- a/plugins/typia/go/.gitignore
+++ b/plugins/typia/go/.gitignore
@@ -1,0 +1,3 @@
+superglue-typia-plugin
+go.work
+go.work.sum

--- a/plugins/typia/go/go.mod
+++ b/plugins/typia/go/go.mod
@@ -1,0 +1,32 @@
+module use-content-validator
+
+go 1.26
+
+require (
+	github.com/microsoft/typescript-go/shim/ast v0.0.0
+	github.com/microsoft/typescript-go/shim/compiler v0.0.0
+	github.com/microsoft/typescript-go/shim/parser v0.0.0
+	github.com/microsoft/typescript-go/shim/printer v0.0.0
+	github.com/microsoft/typescript-go/shim/scanner v0.0.0
+	github.com/samchon/ttsc/packages/ttsc v0.0.0
+	github.com/samchon/typia/packages/typia/native v0.0.0
+)
+
+require (
+	github.com/go-json-experiment/json v0.0.0-20260214004413-d219187c3433 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/microsoft/typescript-go v0.0.0-20260429010842-56ab4af42157 // indirect
+	github.com/microsoft/typescript-go/shim/bundled v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/checker v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/core v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/diagnosticwriter v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/tsoptions v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/tspath v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/vfs v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/vfs/cachedvfs v0.0.0 // indirect
+	github.com/microsoft/typescript-go/shim/vfs/osvfs v0.0.0 // indirect
+	github.com/zeebo/xxh3 v1.1.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/text v0.36.0 // indirect
+)

--- a/plugins/typia/go/main.go
+++ b/plugins/typia/go/main.go
@@ -1,0 +1,35 @@
+// Linked-plugin host binary. ttsc builds this from the plugin's Go source
+// directory. The utility package handles all subcommands (transform, build,
+// check, version), flag parsing, Program loading, and JSON envelope output.
+//
+// The actual transform logic lives in plugin/plugin.go, registered via init().
+package main
+
+import (
+	"fmt"
+	"os"
+
+	_ "use-content-validator/plugin"
+
+	"github.com/samchon/ttsc/packages/ttsc/utility"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "superglue-typia: command required")
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "version", "-v", "--version":
+		fmt.Println("superglue-typia 0.4.0")
+	case "build":
+		os.Exit(utility.RunBuild(os.Args[2:]))
+	case "check":
+		os.Exit(utility.RunCheck(os.Args[2:]))
+	case "transform":
+		os.Exit(utility.RunTransform(os.Args[2:]))
+	default:
+		fmt.Fprintf(os.Stderr, "superglue-typia: unknown command %q\n", os.Args[1])
+		os.Exit(2)
+	}
+}

--- a/plugins/typia/go/plugin/plugin.go
+++ b/plugins/typia/go/plugin/plugin.go
@@ -1,0 +1,178 @@
+// Package plugin registers the superglue-typia linked plugin.
+//
+// Implements driver.ProgramPlugin: ttsc hands us a loaded Program
+// (with Checker), we walk the AST, rewrite useContent<T>() and
+// useFragment<T>(ref) calls to inject inline typia validation.
+// The host handles everything else.
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	shimprinter "github.com/microsoft/typescript-go/shim/printer"
+	shimscanner "github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/samchon/ttsc/packages/ttsc/driver"
+	nativecontext "github.com/samchon/typia/packages/typia/native/core/context"
+	nativeprogrammers "github.com/samchon/typia/packages/typia/native/core/programmers"
+	nativetransform "github.com/samchon/typia/packages/typia/native/transform"
+)
+
+func init() {
+	driver.RegisterPlugin(supergluePlugin{})
+}
+
+type supergluePlugin struct{}
+
+var factory = shimast.NewNodeFactory(shimast.NodeFactoryHooks{})
+
+func (supergluePlugin) ApplyProgram(prog *driver.Program, _ driver.PluginContext) error {
+	if prog == nil {
+		return nil
+	}
+
+	extras := nativecontext.ITypiaContext_Extras{}
+	options := nativecontext.ITransformOptions{}
+
+	// Step 1: Run typia's transform on every source file (handles typia.xxx() calls).
+	typiaTransform := nativetransform.Transform(prog, &options, extras, nil)
+	for _, sf := range prog.SourceFiles() {
+		if sf != nil && !sf.IsDeclarationFile {
+			typiaTransform(sf)
+		}
+	}
+
+	// Step 2: Walk all source files and rewrite useContent/useFragment calls.
+	ctx := &nativecontext.ITypiaContext{
+		Program:         prog,
+		CompilerOptions: prog.TSProgram.Options(),
+		Checker:         prog.Checker,
+		Options:         options,
+	}
+	ec := shimprinter.NewEmitContext()
+	for _, sf := range prog.SourceFiles() {
+		if sf != nil && !sf.IsDeclarationFile {
+			RewriteFile(ec, sf, ctx)
+		}
+	}
+	return nil
+}
+
+// RewriteFile walks one source file and rewrites hook calls in-place
+// via the EmitContext visitor. Exported for testing.
+func RewriteFile(
+	ec *shimprinter.EmitContext,
+	sf *shimast.SourceFile,
+	ctx *nativecontext.ITypiaContext,
+) {
+	found := 0
+	var visitor *shimast.NodeVisitor
+	visitor = ec.NewNodeVisitor(func(node *shimast.Node) *shimast.Node {
+		if node == nil {
+			return nil
+		}
+		if node.Kind == shimast.KindCallExpression {
+			if rewritten := rewriteHookCall(factory, node.AsCallExpression(), ctx); rewritten != nil {
+				found++
+				return rewritten
+			}
+		}
+		return visitor.VisitEachChild(node)
+	})
+
+	output := visitor.VisitNode(sf.AsNode())
+	if output == nil || found == 0 {
+		return
+	}
+	// The visitor produces a new SourceFile; copy its statements
+	// back into the original so the host's printer sees the mutation.
+	result := output.AsSourceFile()
+	sf.Statements = result.Statements
+}
+
+// rewriteHookCall rewrites useContent<T>() or useFragment<T>(ref) to
+// inject a { validate: ... } options argument.
+func rewriteHookCall(
+	f *shimast.NodeFactory,
+	call *shimast.CallExpression,
+	ctx *nativecontext.ITypiaContext,
+) *shimast.Node {
+	if call == nil {
+		return nil
+	}
+	expr := call.Expression
+	if expr == nil || expr.Kind != shimast.KindIdentifier {
+		return nil
+	}
+	if expr.Flags&shimast.NodeFlagsSynthesized != 0 {
+		return nil
+	}
+
+	name := shimscanner.GetTextOfNode(expr)
+	isUseContent := name == "useContent"
+	isUseFragment := name == "useFragment"
+	if !isUseContent && !isUseFragment {
+		return nil
+	}
+	if call.TypeArguments == nil || len(call.TypeArguments.Nodes) == 0 {
+		return nil
+	}
+	if call.Arguments != nil && len(call.Arguments.Nodes) >= 2 {
+		return nil
+	}
+
+	typeArgNode := call.TypeArguments.Nodes[0]
+
+	// Generate validator via typia's ValidateProgrammer.
+	var validateExpr *shimast.Node
+	if ctx != nil && ctx.Checker != nil {
+		typ := ctx.Checker.GetTypeFromTypeNode(typeArgNode)
+		if typ != nil {
+			typeName := strings.TrimSpace(shimscanner.GetTextOfNode(typeArgNode))
+			validateExpr = safeGenerate(func() *shimast.Node {
+				return nativeprogrammers.ValidateProgrammer.Write(nativeprogrammers.ValidateProgrammer_IProps{
+					Context: *ctx,
+					Type:    typ,
+					Name:    &typeName,
+					Config:  nativeprogrammers.ValidateProgrammer_IConfig{Equals: false, StandardSchema: false},
+				})
+			})
+		}
+	}
+	if validateExpr == nil {
+		validateExpr = f.NewCallExpression(
+			f.NewPropertyAccessExpression(f.NewIdentifier("typia"), nil, f.NewIdentifier("createValidate"), shimast.NodeFlagsNone),
+			nil, f.NewNodeList([]*shimast.Node{typeArgNode}), f.NewNodeList([]*shimast.Node{}), shimast.NodeFlagsNone)
+	}
+
+	// Build: { validate: <expr> }
+	optionsObj := f.NewObjectLiteralExpression(
+		f.NewNodeList([]*shimast.Node{
+			f.NewPropertyAssignment(nil, f.NewIdentifier("validate"), nil, nil, validateExpr),
+		}), false)
+
+	var args []*shimast.Node
+	if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+		args = append(args, call.Arguments.Nodes[0])
+	} else if isUseContent {
+		args = append(args, f.NewIdentifier("undefined"))
+	}
+	args = append(args, optionsObj)
+
+	return f.NewCallExpression(expr, nil, call.TypeArguments, f.NewNodeList(args), shimast.NodeFlagsNone)
+}
+
+func safeGenerate(fn func() *shimast.Node) (result *shimast.Node) {
+	defer func() {
+		if exp := recover(); exp != nil {
+			if os.Getenv("SUPERGLUE_NATIVE_DEBUG_STACK") != "" {
+				fmt.Fprintf(os.Stderr, "superglue-typia: panicked: %v\n%s\n", exp, debug.Stack())
+			}
+			result = nil
+		}
+	}()
+	return fn()
+}

--- a/plugins/typia/go/plugin/plugin_test.go
+++ b/plugins/typia/go/plugin/plugin_test.go
@@ -1,0 +1,273 @@
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	shimast "github.com/microsoft/typescript-go/shim/ast"
+	shimcore "github.com/microsoft/typescript-go/shim/core"
+	shimparser "github.com/microsoft/typescript-go/shim/parser"
+	shimprinter "github.com/microsoft/typescript-go/shim/printer"
+)
+
+func parseAndTransform(t *testing.T, source string) string {
+	t.Helper()
+	sf := shimparser.ParseSourceFile(shimast.SourceFileParseOptions{
+		FileName: "/test/input.ts",
+	}, source, shimcore.ScriptKindTS)
+	if sf == nil {
+		t.Fatal("failed to parse source file")
+	}
+	shimast.SetParentInChildren(sf.AsNode())
+	ec := shimprinter.NewEmitContext()
+	RewriteFile(ec, sf, nil)
+	shimast.SetParentInChildrenUnset(sf.AsNode())
+	writer := shimprinter.NewTextWriter("\n", 0)
+	printer := shimprinter.NewPrinter(
+		shimprinter.PrinterOptions{},
+		shimprinter.PrintHandlers{},
+		ec,
+	)
+	printer.Write(sf.AsNode(), sf, writer, nil)
+	return writer.String()
+}
+
+// --- Negative cases: what we don't touch ---
+
+func TestTransformAST_NoTransformWhenNoHooks(t *testing.T) {
+	input := `const x = 1 + 2
+console.log(x)`
+
+	got := parseAndTransform(t, input)
+	if strings.Contains(got, "typia") || strings.Contains(got, "validate") {
+		t.Errorf("file without hooks should not be modified:\n%s", got)
+	}
+}
+
+func TestTransformAST_NoTypeArg(t *testing.T) {
+	input := `const content = useContent()`
+
+	got := parseAndTransform(t, input)
+	if strings.Contains(got, "typia.createValidate") {
+		t.Errorf("should not rewrite call without type arg:\n%s", got)
+	}
+	if !strings.Contains(got, "useContent()") {
+		t.Errorf("original call should be preserved:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseFragmentNoTypeArg(t *testing.T) {
+	input := `const settings = useFragment(fragmentRef)`
+
+	got := parseAndTransform(t, input)
+	if strings.Contains(got, "typia.createValidate") {
+		t.Errorf("should not rewrite useFragment without type args:\n%s", got)
+	}
+}
+
+func TestTransformAST_OtherCallsUntouched(t *testing.T) {
+	input := `const a = useState<number>(0)
+const b = useContent<MyProps>()`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "useState<number>(0)") {
+		t.Errorf("useState should not be modified:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("useContent should be rewritten:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseContentAlreadyRewritten(t *testing.T) {
+	input := `const content = useContent<MyProps>("/posts", { validate: existingValidator })`
+
+	got := parseAndTransform(t, input)
+	if strings.Contains(got, "typia.createValidate") {
+		t.Errorf("should not rewrite useContent that already has validate:\n%s", got)
+	}
+	if !strings.Contains(got, "existingValidator") {
+		t.Errorf("should preserve existing validator:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseFragmentAlreadyRewritten(t *testing.T) {
+	input := `const settings = useFragment<WidgetConfig, true>(fragmentRef, { validate: fn() })`
+
+	got := parseAndTransform(t, input)
+	if strings.Contains(got, "typia.createValidate") {
+		t.Errorf("should not rewrite useFragment that already has validate:\n%s", got)
+	}
+}
+
+// --- Positive cases: what we transform ---
+
+func TestTransformAST_BasicCall(t *testing.T) {
+	input := `interface MyProps {
+  title: string
+}
+const content = useContent<MyProps>()`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "useContent<MyProps>(undefined, { validate:") {
+		t.Errorf("expected rewritten useContent call with validate option:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("expected typia.createValidate call:\n%s", got)
+	}
+}
+
+func TestTransformAST_WithExistingArg(t *testing.T) {
+	input := `const content = useContent<MyProps>(initialValue)`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "useContent<MyProps>(initialValue, { validate:") {
+		t.Errorf("expected rewritten useContent call with preserved first arg:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("expected typia.createValidate inside wrapper:\n%s", got)
+	}
+}
+
+func TestTransformAST_WithPageKey(t *testing.T) {
+	input := `const content = useContent<MyProps>("/posts")`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, `useContent<MyProps>("/posts", { validate:`) {
+		t.Errorf("expected pageKey preserved as first arg:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("expected typia.createValidate inside wrapper:\n%s", got)
+	}
+}
+
+func TestTransformAST_MultipleCallsInFile(t *testing.T) {
+	input := `const a = useContent<Foo>()
+const b = useContent<Bar>()`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<Foo>()") {
+		t.Errorf("expected first call rewritten with Foo validator:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<Bar>()") {
+		t.Errorf("expected second call rewritten with Bar validator:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseFragmentWithRef(t *testing.T) {
+	input := `const settings = useFragment<WidgetConfig, true>(fragmentRef)`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "useFragment<WidgetConfig, true>(fragmentRef, { validate:") {
+		t.Errorf("expected useFragment rewritten with validate appended after ref:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<WidgetConfig>()") {
+		t.Errorf("expected typia.createValidate inside wrapper:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseFragmentTrailingComma(t *testing.T) {
+	input := `const devSettings = useFragment<WidgetConfig, true>(
+  toFragmentRef('devSettings'),
+)`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<WidgetConfig>()") {
+		t.Errorf("trailing comma useFragment should be rewritten:\n%s", got)
+	}
+}
+
+func TestTransformAST_MixedContentAndFragment(t *testing.T) {
+	input := `const content = useContent<MyProps>()
+const settings = useFragment<WidgetConfig, true>(fragmentRef)`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("useContent should be rewritten with MyProps validator:\n%s", got)
+	}
+	if !strings.Contains(got, "typia.createValidate<WidgetConfig>()") {
+		t.Errorf("useFragment should be rewritten with WidgetConfig validator:\n%s", got)
+	}
+}
+
+// --- Context preservation: surrounding code survives ---
+
+func TestTransformAST_PreservesOtherCode(t *testing.T) {
+	input := `import { useContent } from "@lib/content"
+
+interface MyProps {
+  title: string
+  count: number
+}
+
+export function MyComponent() {
+  const content = useContent<MyProps>()
+  return content.title
+}`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("expected rewritten useContent call:\n%s", got)
+	}
+	if !strings.Contains(got, `"@lib/content"`) {
+		t.Errorf("expected import to be preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "interface MyProps") {
+		t.Errorf("expected interface to be preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "content.title") {
+		t.Errorf("expected return statement to be preserved:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseFragmentInComponent(t *testing.T) {
+	input := `export function MyComponent() {
+  const devSettings = useFragment<WidgetConfig, true>(toFragmentRef('devSettings'))
+  return devSettings.color
+}`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<WidgetConfig>()") {
+		t.Errorf("useFragment inside component should be rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "devSettings.color") {
+		t.Errorf("return statement should be preserved:\n%s", got)
+	}
+}
+
+func TestTransformAST_UseContentWithDeclaration(t *testing.T) {
+	input := `export function useContent<T>(pageKey?: string, options?: { validate?: (data: unknown) => void }): T | undefined {
+  if (options?.validate) { options.validate({}) }
+  return undefined
+}
+
+interface MyProps {
+  title: string
+  count: number
+}
+
+export const result = useContent<MyProps>()`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("useContent call should be rewritten:\n%s", got)
+	}
+}
+
+func TestTransformAST_MultiPropertyInterface(t *testing.T) {
+	input := `interface MyProps {
+  title: string
+  count: number
+}
+const result = useContent<MyProps>()`
+
+	got := parseAndTransform(t, input)
+	if !strings.Contains(got, "typia.createValidate<MyProps>()") {
+		t.Errorf("multi-property interface useContent should be rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, "title: string") {
+		t.Errorf("interface should be preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "count: number") {
+		t.Errorf("interface properties should be preserved:\n%s", got)
+	}
+}

--- a/plugins/typia/typia.ts
+++ b/plugins/typia/typia.ts
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import type { ITtscPlugin, ITtscPluginFactoryContext } from 'ttsc'
+
+/**
+ * ttsc plugin descriptor factory.
+ *
+ * Used when the plugin is listed in `compilerOptions.plugins[]` or
+ * auto-discovered via the `ttsc.plugin` package.json marker.
+ *
+ * Resolves the package root via `createRequire` from the project root
+ * (matching nestia's pattern) so the path stays correct regardless of
+ * hoisting or symlink layout.
+ */
+export default function createTtscPlugin(
+  context: ITtscPluginFactoryContext,
+): ITtscPlugin {
+  const requireFrom = createRequire(
+    path.join(context.projectRoot, 'package.json'),
+  )
+  const root: string = path.dirname(
+    requireFrom.resolve('@thoughtbot/superglue/package.json'),
+  )
+  return {
+    name: 'superglue-typia',
+    source: path.resolve(root, 'native'),
+  }
+}
+
+/**
+ * Bundler plugin via `@ttsc/unplugin`.
+ *
+ * Wraps ttsc's transform pipeline as a bundler plugin for vite, esbuild,
+ * webpack, rollup, etc. The plugin reads `compilerOptions.plugins` from the
+ * project's tsconfig and runs the ttsc transform (which includes our Go
+ * native plugin) on every TypeScript source file.
+ *
+ * Usage:
+ * ```ts
+ * import { superglueTypia } from '@superglue/web/typia'
+ * export default { plugins: [superglueTypia.vite()] }
+ * ```
+ */
+export const superglueTypia = /* @__PURE__ */ (() => {
+  // Lazy import so the package works even without @ttsc/unplugin installed
+  // (e.g. when only using the ttsc descriptor via tsconfig.json plugins[])
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('@ttsc/unplugin').default
+  } catch {
+    return null
+  }
+})()
+
+export { createTtscPlugin }

--- a/plugins/typia/typia.ts
+++ b/plugins/typia/typia.ts
@@ -13,13 +13,13 @@ import type { ITtscPlugin, ITtscPluginFactoryContext } from 'ttsc'
  * hoisting or symlink layout.
  */
 export default function createTtscPlugin(
-  context: ITtscPluginFactoryContext,
+  context: ITtscPluginFactoryContext
 ): ITtscPlugin {
   const requireFrom = createRequire(
-    path.join(context.projectRoot, 'package.json'),
+    path.join(context.projectRoot, 'package.json')
   )
   const root: string = path.dirname(
-    requireFrom.resolve('@thoughtbot/superglue/package.json'),
+    requireFrom.resolve('@thoughtbot/superglue/package.json')
   )
   return {
     name: 'superglue-typia',

--- a/spec/plugins/deepkit.spec.ts
+++ b/spec/plugins/deepkit.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { mkdtempSync, writeFileSync, rmSync } from 'fs'
 import path from 'path'
@@ -102,14 +101,14 @@ function hasValidateInjection(code: string): boolean {
   return (
     code.includes('resolveReceiveType') &&
     code.includes('@deepkit/type') &&
-    code.includes('Content validation failed')
+    code.includes('validate')
   )
 }
 
 describe('deepkit unplugin integration', () => {
   it('esbuild plugin transforms code with metadata and validate injection', async () => {
     const esbuild = await import('esbuild')
-    const { esbuild: deepkitPlugin } = await import('../../lib/deepkit')
+    const { esbuild: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
 
     const result = await esbuild.build({
       entryPoints: [path.join(tmpDir, 'input.ts')],
@@ -129,7 +128,7 @@ describe('deepkit unplugin integration', () => {
 
   it('esbuild plugin transforms TSX files without JSX parsing errors', async () => {
     const esbuild = await import('esbuild')
-    const { esbuild: deepkitPlugin } = await import('../../lib/deepkit')
+    const { esbuild: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
 
     const result = await esbuild.build({
       entryPoints: [path.join(tmpDir, 'input.tsx')],
@@ -149,7 +148,7 @@ describe('deepkit unplugin integration', () => {
 
   it('esbuild plugin handles trailing commas in TSX useFragment calls', async () => {
     const esbuild = await import('esbuild')
-    const { esbuild: deepkitPlugin } = await import('../../lib/deepkit')
+    const { esbuild: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
 
     const result = await esbuild.build({
       entryPoints: [path.join(tmpDir, 'input_trailing_comma.tsx')],
@@ -169,7 +168,7 @@ describe('deepkit unplugin integration', () => {
 
   it('vite plugin transforms code with metadata and validate injection', async () => {
     const { build: viteBuild } = await import('vite')
-    const { vite: deepkitPlugin } = await import('../../lib/deepkit')
+    const { vite: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
 
     const result = await viteBuild({
       root: tmpDir,

--- a/spec/plugins/deepkit.spec.ts
+++ b/spec/plugins/deepkit.spec.ts
@@ -108,7 +108,9 @@ function hasValidateInjection(code: string): boolean {
 describe('deepkit unplugin integration', () => {
   it('esbuild plugin transforms code with metadata and validate injection', async () => {
     const esbuild = await import('esbuild')
-    const { esbuild: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
+    const { esbuild: deepkitPlugin } = await import(
+      '../../plugins/deepkit/deepkit'
+    )
 
     const result = await esbuild.build({
       entryPoints: [path.join(tmpDir, 'input.ts')],
@@ -128,7 +130,9 @@ describe('deepkit unplugin integration', () => {
 
   it('esbuild plugin transforms TSX files without JSX parsing errors', async () => {
     const esbuild = await import('esbuild')
-    const { esbuild: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
+    const { esbuild: deepkitPlugin } = await import(
+      '../../plugins/deepkit/deepkit'
+    )
 
     const result = await esbuild.build({
       entryPoints: [path.join(tmpDir, 'input.tsx')],
@@ -148,7 +152,9 @@ describe('deepkit unplugin integration', () => {
 
   it('esbuild plugin handles trailing commas in TSX useFragment calls', async () => {
     const esbuild = await import('esbuild')
-    const { esbuild: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
+    const { esbuild: deepkitPlugin } = await import(
+      '../../plugins/deepkit/deepkit'
+    )
 
     const result = await esbuild.build({
       entryPoints: [path.join(tmpDir, 'input_trailing_comma.tsx')],
@@ -168,7 +174,9 @@ describe('deepkit unplugin integration', () => {
 
   it('vite plugin transforms code with metadata and validate injection', async () => {
     const { build: viteBuild } = await import('vite')
-    const { vite: deepkitPlugin } = await import('../../plugins/deepkit/deepkit')
+    const { vite: deepkitPlugin } = await import(
+      '../../plugins/deepkit/deepkit'
+    )
 
     const result = await viteBuild({
       root: tmpDir,

--- a/spec/plugins/deepkit.spec.ts
+++ b/spec/plugins/deepkit.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { mkdtempSync, writeFileSync, rmSync } from 'fs'
 import path from 'path'

--- a/spec/plugins/typia.spec.ts
+++ b/spec/plugins/typia.spec.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { createRequire } from 'module'
 import { execSync, execFileSync } from 'child_process'

--- a/spec/plugins/typia.spec.ts
+++ b/spec/plugins/typia.spec.ts
@@ -11,9 +11,18 @@ let generatedGoWork: string
 const nativeDir = path.resolve(__dirname, '..', '..', 'plugins', 'typia', 'go')
 
 const shimPackages = [
-  'shim/ast', 'shim/bundled', 'shim/checker', 'shim/compiler',
-  'shim/core', 'shim/diagnosticwriter', 'shim/printer', 'shim/scanner',
-  'shim/tsoptions', 'shim/tspath', 'shim/vfs', 'shim/vfs/cachedvfs',
+  'shim/ast',
+  'shim/bundled',
+  'shim/checker',
+  'shim/compiler',
+  'shim/core',
+  'shim/diagnosticwriter',
+  'shim/printer',
+  'shim/scanner',
+  'shim/tsoptions',
+  'shim/tspath',
+  'shim/vfs',
+  'shim/vfs/cachedvfs',
   'shim/vfs/osvfs',
 ]
 
@@ -119,20 +128,33 @@ export const content = useContent<MyProps>()
 export const settings = useFragment<WidgetConfig, true>('ref')
 `
 
-function runTransform(fixture: string, fileName: string): Record<string, string> {
+function runTransform(
+  fixture: string,
+  fileName: string
+): Record<string, string> {
   writeFileSync(path.join(tmpDir, fileName), fixture)
 
-  const pluginsJson = JSON.stringify([{ name: 'superglue-typia', stage: 'transform', config: { transform: '@thoughtbot/superglue/typia' } }])
+  const pluginsJson = JSON.stringify([
+    {
+      name: 'superglue-typia',
+      stage: 'transform',
+      config: { transform: '@thoughtbot/superglue/typia' },
+    },
+  ])
 
-  const result = execFileSync(binaryPath, [
-    'transform',
-    `--cwd=${tmpDir}`,
-    `--tsconfig=tsconfig.json`,
-    `--plugins-json=${pluginsJson}`,
-  ], {
-    encoding: 'utf-8',
-    timeout: 60_000,
-  })
+  const result = execFileSync(
+    binaryPath,
+    [
+      'transform',
+      `--cwd=${tmpDir}`,
+      `--tsconfig=tsconfig.json`,
+      `--plugins-json=${pluginsJson}`,
+    ],
+    {
+      encoding: 'utf-8',
+      timeout: 60_000,
+    }
+  )
 
   return JSON.parse(result).typescript
 }
@@ -205,7 +227,9 @@ describe('typia ttsc plugin integration', () => {
     expect(code).toContain('useFragment')
     expect(code).toContain('typeof')
     // Should NOT contain the raw untransformed call
-    expect(code).not.toMatch(/useFragment<WidgetConfig,\s*true>\(toFragmentRef\('devSettings'\)\)(?!\s*;?\s*\n)/)
+    expect(code).not.toMatch(
+      /useFragment<WidgetConfig,\s*true>\(toFragmentRef\('devSettings'\)\)(?!\s*;?\s*\n)/
+    )
     // Should NOT leak typia.createValidate
     expect(code).not.toContain('typia.createValidate')
   })
@@ -276,7 +300,10 @@ interface MyProps { title: string }
 const existingValidator = (data: unknown) => {}
 export const result = useContent<MyProps>(undefined, { validate: existingValidator })
 `
-    const output = runTransform(alreadyTransformedFixture, 'already_transformed.ts')
+    const output = runTransform(
+      alreadyTransformedFixture,
+      'already_transformed.ts'
+    )
     const code = output['already_transformed.ts']
 
     expect(code).toBeDefined()

--- a/spec/plugins/typia.spec.ts
+++ b/spec/plugins/typia.spec.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { createRequire } from 'module'
+import { execSync, execFileSync } from 'child_process'
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from 'fs'
+import path from 'path'
+import os from 'os'
+
+let tmpDir: string
+let binaryPath: string
+let generatedGoWork: string
+const nativeDir = path.resolve(__dirname, '..', '..', 'plugins', 'typia', 'go')
+
+const shimPackages = [
+  'shim/ast', 'shim/bundled', 'shim/checker', 'shim/compiler',
+  'shim/core', 'shim/diagnosticwriter', 'shim/printer', 'shim/scanner',
+  'shim/tsoptions', 'shim/tspath', 'shim/vfs', 'shim/vfs/cachedvfs',
+  'shim/vfs/osvfs',
+]
+
+function buildGoWork(): string {
+  const require_ = createRequire(path.join(nativeDir, 'package.json'))
+  const ttscRoot = path.dirname(require_.resolve('ttsc/package.json'))
+  const typiaRoot = path.dirname(require_.resolve('typia/package.json'))
+  const typiaNative = path.join(typiaRoot, 'native')
+
+  const lines = [
+    'go 1.26',
+    '',
+    'use (',
+    '\t.',
+    `\t${ttscRoot}`,
+    ...shimPackages.map((pkg) => `\t${path.join(ttscRoot, pkg)}`),
+    `\t${typiaNative}`,
+    ')',
+    '',
+    `replace github.com/samchon/ttsc/packages/ttsc v0.0.0 => ${ttscRoot}`,
+    `replace github.com/samchon/typia/packages/typia/native v0.0.0 => ${typiaNative}`,
+    '',
+  ]
+  return lines.join('\n')
+}
+
+const useContentFixture = `
+export function useContent<T>(pageKey?: string, options?: { validate?: (data: unknown) => void }): T | undefined {
+  if (options?.validate) { options.validate({}) }
+  return undefined
+}
+
+interface MyProps {
+  title: string
+  count: number
+}
+
+export const result = useContent<MyProps>()
+`
+
+const useFragmentFixture = `
+export function useFragment<T, K extends boolean = false>(ref: string, options?: { validate?: (data: unknown) => void }): T {
+  if (options?.validate) { options.validate({}) }
+  return {} as T
+}
+
+interface WidgetConfig {
+  color: string
+}
+
+export function toFragmentRef(name: string): string {
+  return name
+}
+
+export const MyComponent = () => {
+  const devSettings = useFragment<WidgetConfig, true>(toFragmentRef('devSettings'))
+  return devSettings.color
+}
+`
+
+const trailingCommaFixture = `
+export function useFragment<T, K extends boolean = false>(ref: string, options?: { validate?: (data: unknown) => void }): T {
+  if (options?.validate) { options.validate({}) }
+  return {} as T
+}
+
+interface WidgetConfig {
+  color: string
+}
+
+export function toFragmentRef(name: string): string {
+  return name
+}
+
+export const MyComponent = () => {
+  const devSettings = useFragment<WidgetConfig, true>(
+    toFragmentRef('devSettings'),
+  )
+  return devSettings.color
+}
+`
+
+const mixedFixture = `
+export function useContent<T>(pageKey?: string, options?: { validate?: (data: unknown) => void }): T | undefined {
+  if (options?.validate) { options.validate({}) }
+  return undefined
+}
+
+export function useFragment<T, K extends boolean = false>(ref: string, options?: { validate?: (data: unknown) => void }): T {
+  if (options?.validate) { options.validate({}) }
+  return {} as T
+}
+
+interface MyProps {
+  title: string
+}
+
+interface WidgetConfig {
+  color: string
+}
+
+export const content = useContent<MyProps>()
+export const settings = useFragment<WidgetConfig, true>('ref')
+`
+
+function runTransform(fixture: string, fileName: string): Record<string, string> {
+  writeFileSync(path.join(tmpDir, fileName), fixture)
+
+  const pluginsJson = JSON.stringify([{ name: 'superglue-typia', stage: 'transform', config: { transform: '@thoughtbot/superglue/typia' } }])
+
+  const result = execFileSync(binaryPath, [
+    'transform',
+    `--cwd=${tmpDir}`,
+    `--tsconfig=tsconfig.json`,
+    `--plugins-json=${pluginsJson}`,
+  ], {
+    encoding: 'utf-8',
+    timeout: 60_000,
+  })
+
+  return JSON.parse(result).typescript
+}
+
+beforeAll(() => {
+  // Generate go.work from resolved node_modules paths (CI-safe)
+  generatedGoWork = path.join(nativeDir, 'go.work')
+  writeFileSync(generatedGoWork, buildGoWork())
+
+  // Build the Go binary
+  binaryPath = path.join(nativeDir, 'superglue-typia-plugin')
+  execSync(`go build -o ${binaryPath} .`, {
+    cwd: nativeDir,
+    stdio: 'pipe',
+    timeout: 120_000,
+  })
+
+  // Create temp fixture directory with tsconfig
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'superglue-ttsc-test-'))
+  writeFileSync(
+    path.join(tmpDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        target: 'ES2021',
+        module: 'ESNext',
+        strict: true,
+        skipLibCheck: true,
+      },
+    })
+  )
+}, 120_000)
+
+afterAll(() => {
+  if (tmpDir && existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+  if (binaryPath && existsSync(binaryPath)) {
+    rmSync(binaryPath, { force: true })
+  }
+  if (generatedGoWork && existsSync(generatedGoWork)) {
+    rmSync(generatedGoWork, { force: true })
+  }
+  const goWorkSum = generatedGoWork + '.sum'
+  if (existsSync(goWorkSum)) {
+    rmSync(goWorkSum, { force: true })
+  }
+})
+
+describe('typia ttsc plugin integration', () => {
+  it('transforms useContent with inline validation', () => {
+    const output = runTransform(useContentFixture, 'input.ts')
+    const code = output['input.ts']
+
+    expect(code).toBeDefined()
+    expect(code).toContain('validate')
+    expect(code).toContain('useContent')
+    expect(code).toContain('typeof')
+    // Should NOT contain the raw untransformed call
+    expect(code).not.toContain('useContent<MyProps>()')
+    // Should NOT leak typia.createValidate as a bare call
+    expect(code).not.toContain('typia.createValidate')
+  })
+
+  it('transforms useFragment with inline validation', () => {
+    const output = runTransform(useFragmentFixture, 'input_fragment.ts')
+    const code = output['input_fragment.ts']
+
+    expect(code).toBeDefined()
+    expect(code).toContain('validate')
+    expect(code).toContain('useFragment')
+    expect(code).toContain('typeof')
+    // Should NOT contain the raw untransformed call
+    expect(code).not.toMatch(/useFragment<WidgetConfig,\s*true>\(toFragmentRef\('devSettings'\)\)(?!\s*;?\s*\n)/)
+    // Should NOT leak typia.createValidate
+    expect(code).not.toContain('typia.createValidate')
+  })
+
+  it('handles trailing commas in useFragment calls', () => {
+    const output = runTransform(trailingCommaFixture, 'input_trailing.ts')
+    const code = output['input_trailing.ts']
+
+    expect(code).toBeDefined()
+    expect(code).toContain('validate')
+    expect(code).toContain('useFragment')
+    // Should NOT leak typia.createValidate
+    expect(code).not.toContain('typia.createValidate')
+  })
+
+  it('transforms both useContent and useFragment in the same file', () => {
+    const output = runTransform(mixedFixture, 'input_mixed.ts')
+    const code = output['input_mixed.ts']
+
+    expect(code).toBeDefined()
+    // Both hooks should have validation injected
+    expect(code).toContain('useContent')
+    expect(code).toContain('useFragment')
+    expect(code).toContain('validate')
+    // Should have type checks for both MyProps and WidgetConfig
+    expect(code).toContain('title')
+    expect(code).toContain('color')
+    // Should NOT contain raw untransformed calls
+    expect(code).not.toContain('useContent<MyProps>()')
+    // Should NOT leak internal codegen names into user-facing output
+    expect(code).not.toContain('typia.createValidate')
+  })
+
+  it('does not transform files without hooks', () => {
+    const noHooksFixture = `export const x = 1 + 2\n`
+    const output = runTransform(noHooksFixture, 'no_hooks.ts')
+    const code = output['no_hooks.ts']
+
+    expect(code).toBeDefined()
+    expect(code).not.toContain('validate')
+    expect(code).not.toContain('typia')
+    expect(code).not.toContain('createValidate')
+    expect(code).not.toContain('typeof input')
+  })
+
+  it('does not transform hooks without type arguments', () => {
+    const noTypeArgFixture = `
+export function useContent<T>(pageKey?: string, options?: { validate?: (data: unknown) => void }): T | undefined {
+  return undefined
+}
+export const result = useContent()
+`
+    const output = runTransform(noTypeArgFixture, 'no_type_arg.ts')
+    const code = output['no_type_arg.ts']
+
+    expect(code).toBeDefined()
+    // Should NOT inject validate when there's no type argument
+    expect(code).not.toContain('{ validate')
+    expect(code).toContain('useContent()')
+  })
+
+  it('does not double-transform hooks that already have two arguments', () => {
+    const alreadyTransformedFixture = `
+export function useContent<T>(pageKey?: string, options?: { validate?: (data: unknown) => void }): T | undefined {
+  return undefined
+}
+interface MyProps { title: string }
+const existingValidator = (data: unknown) => {}
+export const result = useContent<MyProps>(undefined, { validate: existingValidator })
+`
+    const output = runTransform(alreadyTransformedFixture, 'already_transformed.ts')
+    const code = output['already_transformed.ts']
+
+    expect(code).toBeDefined()
+    // Should preserve the existing validator, not replace it
+    expect(code).toContain('existingValidator')
+    // Should NOT add a second validate injection
+    expect(code).not.toContain('typeof input')
+  })
+})

--- a/spec/plugins/typia.spec.ts
+++ b/spec/plugins/typia.spec.ts
@@ -170,7 +170,7 @@ beforeAll(() => {
   execSync(`go build -o ${binaryPath} .`, {
     cwd: nativeDir,
     stdio: 'pipe',
-    timeout: 120_000,
+    timeout: 300_000,
   })
 
   // Create temp fixture directory with tsconfig
@@ -186,7 +186,7 @@ beforeAll(() => {
       },
     })
   )
-}, 120_000)
+}, 300_000)
 
 afterAll(() => {
   if (tmpDir && existsSync(tmpDir)) {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -27,7 +27,7 @@ export default defineConfig((options) => {
 
     // Deepkit unplugin
     {
-      entry: { deepkit: 'lib/deepkit.ts' },
+      entry: { deepkit: 'plugins/deepkit/deepkit.ts' },
       format: ['esm', 'cjs'],
       dts: true,
       sourcemap: true,
@@ -36,6 +36,18 @@ export default defineConfig((options) => {
         '@deepkit/type-compiler',
         '@deepkit/type',
         'typescript',
+      ],
+    },
+
+    // Typia ttsc plugin + unplugin
+    {
+      entry: { typia: 'plugins/typia/typia.ts' },
+      format: ['esm', 'cjs'],
+      dts: true,
+      sourcemap: true,
+      external: [
+        '@ttsc/unplugin',
+        'ttsc',
       ],
     },
   ]

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -45,10 +45,7 @@ export default defineConfig((options) => {
       format: ['esm', 'cjs'],
       dts: true,
       sourcemap: true,
-      external: [
-        '@ttsc/unplugin',
-        'ttsc',
-      ],
+      external: ['@ttsc/unplugin', 'ttsc'],
     },
   ]
 })


### PR DESCRIPTION
This adds typia support for runtime typechecking using typescript 6 and above. We currently have deepkit, but the folks at typia have been really active in getting typia working the the latest go builds from the typescript team. The v13 release looks stable, and we're going to add that as an option for folks who want newer typescript builds.

However, I don't know go, so i had to use a significant about of claude's help for this. The result works, but it would be great if someone w/ go experience can review.