### PR TITLE
Refactor: Move useContent smoke test to useContent.spec.jsx

### DIFF
--- a/superglue/spec/lib/hooks.spec.jsx
+++ b/superglue/spec/lib/hooks.spec.jsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react'
-import { useContent, useSuperglue, useFlash, useSetFlash } from '../../lib'
+import { useSuperglue, useFlash, useSetFlash } from '../../lib'
 import { flashReducer } from '../../lib/reducers'
 import { describe, it } from 'vitest'
 import { Provider } from 'react-redux'
@@ -28,45 +28,6 @@ describe('hooks', () => {
       const { result } = renderHook(() => useSuperglue(), { wrapper })
 
       expect(result.current).toEqual(preloadedState.superglue)
-    })
-  })
-
-  describe('useContent', () => {
-    it('returns the page content', () => {
-      const preloadedState = {
-        superglue: {
-          currentPageKey: '/current?abc=123',
-          pathname: '/current',
-          search: '?abc=123',
-          csrfToken: 'csrf123',
-          assets: ['js-asset-123'],
-        },
-        pages: {
-          '/current?abc=123': {
-            data: {
-              heading: 'selected',
-            },
-          },
-          '/other': {
-            data: {
-              heading: 'not selected',
-            },
-          },
-        },
-      }
-
-      let store = configureStore({
-        preloadedState,
-        reducer: (state) => state,
-      })
-      const wrapper = ({ children }) => (
-        <Provider store={store}>{children}</Provider>
-      )
-      const { result } = renderHook(() => useContent(), { wrapper })
-
-      expect(result.current).toEqual({
-        heading: 'selected',
-      })
     })
   })
 

--- a/superglue/spec/lib/useContent.spec.jsx
+++ b/superglue/spec/lib/useContent.spec.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, act, waitFor } from '@testing-library/react'
+import { render, renderHook, act, waitFor } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import { rootReducer } from '../../lib/reducers'
@@ -32,6 +32,43 @@ describe('useContent', () => {
   const renderWithProvider = (component, store) => {
     return render(<Provider store={store}>{component}</Provider>)
   }
+
+  it('returns the page content', () => {
+    const preloadedState = {
+      superglue: {
+        currentPageKey: '/current?abc=123',
+        pathname: '/current',
+        search: '?abc=123',
+        csrfToken: 'csrf123',
+        assets: ['js-asset-123'],
+      },
+      pages: {
+        '/current?abc=123': {
+          data: {
+            heading: 'selected',
+          },
+        },
+        '/other': {
+          data: {
+            heading: 'not selected',
+          },
+        },
+      },
+    }
+
+    let store = configureStore({
+      preloadedState,
+      reducer: (state) => state,
+    })
+    const wrapper = ({ children }) => (
+      <Provider store={store}>{children}</Provider>
+    )
+    const { result } = renderHook(() => useContent(), { wrapper })
+
+    expect(result.current).toEqual({
+      heading: 'selected',
+    })
+  })
 
   describe('basic functionality', () => {
     it('returns proxied page data for current page', () => {


### PR DESCRIPTION
## Summary
- Move useContent smoke test from hooks.spec.jsx into the existing useContent.spec.jsx

Closes #210